### PR TITLE
Added scripts to export Identity Pool Usage

### DIFF
--- a/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
+++ b/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
@@ -1,0 +1,216 @@
+﻿<#
+_author_ = Trevor Squillario <Trevor.Squillario@Dell.com>
+_version_ = 0.1
+
+Copyright (c) 2018 Dell EMC Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+<#
+ .SYNOPSIS
+   Script to get the list of virtual addresses in an Identity Pool
+ .DESCRIPTION
+
+   This script exercises the OME REST API to get a list of virtual addresses in an Identity Pool.
+
+   Will export to a CSV file called IdentityPoolUsage.csv in the current directory
+
+   For authentication X-Auth is used over Basic Authentication
+
+   Note that the credentials entered are not stored to disk.
+
+ .PARAMETER IpAddress
+   This is the IP address of the OME Appliance
+ .PARAMETER Credentials
+   Credentials used to talk to the OME Appliance
+ .PARAMETER IdentityPoolId
+   This is the Identity Pool Id
+ .PARAMETER OutFile
+   This is the full path to output the CSV file
+
+ .EXAMPLE
+   $cred = Get-Credential
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -Credentials $cred
+
+ .EXAMPLE
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx"
+   In this instance you will be prompted for credentials to use
+
+ .EXAMPLE
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -IdentityPoolId 3
+   In this instance you will be prompted for credentials to use
+
+ .EXAMPLE
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -IdentityPoolId 3 -OutFile C:\Temp\export.csv
+   In this instance you will be prompted for credentials to use
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [System.Net.IPAddress] $IpAddress,
+
+    [Parameter(Mandatory)]
+    [pscredential] $Credentials,
+
+    [Parameter(Mandatory=$false)]
+    [String] $IdentityPoolId,
+
+    [Parameter(Mandatory=$false)]
+    [String] $OutFile
+)
+
+function Set-CertPolicy() {
+## Trust all certs - for sample usage only
+Try {
+add-type @"
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+public class TrustAllCertsPolicy : ICertificatePolicy {
+    public bool CheckValidationResult(
+        ServicePoint srvPoint, X509Certificate certificate,
+        WebRequest request, int certificateProblem) {
+        return true;
+    }
+}
+"@
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    }
+    Catch {
+        Write-Error "Unable to add type for cert policy"
+    }
+}
+
+Try {
+    Set-CertPolicy
+    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
+    $BaseUri = "https://$($IpAddress)"
+    $NextLinkUrl = $null
+    $Type        = "application/json"
+    $UserName    = $Credentials.username
+    $Password    = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
+    $Headers     = @{}
+
+    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
+        ## Successfully created a session - extract the auth token from the response
+        ## header and update our headers for subsequent requests
+        $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
+        
+        # Display Identity Pools
+        $IdentityPoolUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools"
+        $IdentityPoolResp = Invoke-WebRequest -Uri $IdentityPoolUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        if ($IdentityPoolResp.StatusCode -eq 200) {
+            $IdentityPoolRespData = $IdentityPoolResp.Content | ConvertFrom-Json
+            $IdentityPoolRespData = $IdentityPoolRespData.'value'
+
+            if ($IdentityPoolId -eq "") {
+                $IdentityPoolRespData | Select Id, Name | Out-String
+                $IdentityPoolId = Read-Host "Please Enter Identity Pool Id"
+            }
+        }
+
+        # Get Identity Pool Usage Sets
+        $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($IdentityPoolId))/UsageIdentitySets"
+        $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        if ($IdentityPoolUsageSetResp.StatusCode -eq 200) {
+            $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
+            $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetRespData.'value'
+
+            $DeviceData = @()
+            # Loop through Usage Sets using Id to get Details
+            foreach ($IdentitySet in $IdentityPoolUsageSetRespData) {    
+                $IdentitySetId = $IdentitySet.IdentitySetId
+                $IdentitySetName = $IdentitySet.Name
+
+                $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($IdentityPoolId))/UsageIdentitySets($($IdentitySetId))/Details"
+                $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                if ($IdentityPoolUsageDetailResp.StatusCode -eq 200) {
+                    $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json
+                    # Loop through Details appending to object array
+                    foreach($DeviceEntry in $IdentityPoolUsageDetailData.'value')
+                    {
+                        $DeviceDetails =@{
+                            IdentityType = $IdentitySetName
+                            ChassisName = $DeviceEntry.DeviceInfo.ChassisName
+                            ServerName = $DeviceEntry.DeviceInfo.ServerName
+                            ManagementIp = $DeviceEntry.DeviceInfo.ManagementIp
+                            NicIdentifier = $DeviceEntry.NicIdentifier
+                            MacAddress = $DeviceEntry.MacAddress
+                        }
+                        $DeviceData += New-Object PSObject -Property $DeviceDetails 
+                    }
+
+                    # Check if there are multiple pages in response
+                    if ($IdentityPoolUsageDetailData.'@odata.nextLink'){
+                        $NextLinkUrl = $BaseUri + $IdentityPoolUsageDetailData.'@odata.nextLink'
+                    }
+                    # Loop through pages until end
+                    while ($NextLinkUrl) {
+                        $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                        if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -eq 200) {
+                            $IdentityPoolUsageDetailNextLinkData = $IdentityPoolUsageDetailNextLinkResp.Content | ConvertFrom-Json
+                            # Loop through Details appending to object array
+                            foreach($DeviceEntry in $IdentityPoolUsageDetailNextLinkData.'value')
+                            {
+                                $DeviceDetails =@{
+                                    IdentityType = $IdentitySetName
+                                    ChassisName = $DeviceEntry.DeviceInfo.ChassisName
+                                    ServerName = $DeviceEntry.DeviceInfo.ServerName
+                                    ManagementIp = $DeviceEntry.DeviceInfo.ManagementIp
+                                    NicIdentifier = $DeviceEntry.NicIdentifier
+                                    MacAddress = $DeviceEntry.MacAddress
+                                }
+                                $DeviceData += New-Object PSObject -Property $DeviceDetails 
+                            }
+                            # Set for nextLink for next iteration
+                            if ($IdentityPoolUsageDetailNextLinkData.'@odata.nextLink'){
+                                $NextLinkUrl = $BaseUri + $IdentityPoolUsageDetailNextLinkData.'@odata.nextLink'
+                            } else { 
+                                $NextLinkUrl = $null
+                            }
+                        }
+                    }
+                }
+                else {
+                    Write-Error "Unable to get identity pools... Exiting"
+                }
+            }
+
+            # Print table to console
+            $DeviceData | Format-Table | Out-String
+
+            # Export to CSV
+            if ($DeviceData.Count -gt 0) {
+                if ($OutFile -eq "") {
+                    $DeviceData | Export-Csv -Path "IdentityPoolUsage.csv" -NoTypeInformation
+                    Write-Host "Exported data to $(Get-Location)\IdentityPoolUsage.csv"
+                } else {
+                    $DeviceData | Export-Csv -Path $OutFile -NoTypeInformation
+                    Write-Host "Exported data to $($OutFile)"
+                }
+            } else {
+                Write-Host "No data to display"
+            }
+        }
+    
+    }
+    else {
+        Write-Error "Unable to create a session with appliance $($IpAddress)"
+    }
+}
+Catch {
+    Write-Error "Exception occured - $($_.Exception.Message)"
+}

--- a/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
+++ b/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
@@ -31,7 +31,7 @@ limitations under the License.
    This is the IP address of the OME Appliance
  .PARAMETER Credentials
    Credentials used to talk to the OME Appliance
- .PARAMETER IdentityPoolId
+ .PARAMETER Id
    This is the Identity Pool Id
  .PARAMETER OutFile
    This is the full path to output the CSV file
@@ -45,11 +45,11 @@ limitations under the License.
    In this instance you will be prompted for credentials to use
 
  .EXAMPLE
-   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -IdentityPoolId 3
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -Id 3
    In this instance you will be prompted for credentials to use
 
  .EXAMPLE
-   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -IdentityPoolId 3 -OutFile C:\Temp\export.csv
+   .\Get-IdentityPoolUsage.ps1 -IpAddress "10.xx.xx.xx" -Id 3 -OutFile C:\Temp\export.csv
    In this instance you will be prompted for credentials to use
 #>
 [CmdletBinding()]
@@ -61,7 +61,7 @@ param(
     [pscredential] $Credentials,
 
     [Parameter(Mandatory=$false)]
-    [String] $IdentityPoolId,
+    [String] $Id,
 
     [Parameter(Mandatory=$false)]
     [String] $OutFile
@@ -113,14 +113,14 @@ Try {
             $IdentityPoolRespData = $IdentityPoolResp.Content | ConvertFrom-Json
             $IdentityPoolRespData = $IdentityPoolRespData.'value'
 
-            if ($IdentityPoolId -eq "") {
+            if ($Id -eq "") {
                 $IdentityPoolRespData | Select Id, Name | Out-String
-                $IdentityPoolId = Read-Host "Please Enter Identity Pool Id"
+                $Id = Read-Host "Please Enter Identity Pool Id"
             }
         }
 
         # Get Identity Pool Usage Sets
-        $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($IdentityPoolId))/UsageIdentitySets"
+        $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets"
         $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
         if ($IdentityPoolUsageSetResp.StatusCode -eq 200) {
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
@@ -132,7 +132,7 @@ Try {
                 $IdentitySetId = $IdentitySet.IdentitySetId
                 $IdentitySetName = $IdentitySet.Name
 
-                $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($IdentityPoolId))/UsageIdentitySets($($IdentitySetId))/Details"
+                $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets($($IdentitySetId))/Details"
                 $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
                 if ($IdentityPoolUsageDetailResp.StatusCode -eq 200) {
                     $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json

--- a/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
+++ b/Scripts/PowerShell/Get-IdentityPoolUsage.ps1
@@ -23,11 +23,8 @@ limitations under the License.
  .DESCRIPTION
 
    This script exercises the OME REST API to get a list of virtual addresses in an Identity Pool.
-
    Will export to a CSV file called IdentityPoolUsage.csv in the current directory
-
    For authentication X-Auth is used over Basic Authentication
-
    Note that the credentials entered are not stored to disk.
 
  .PARAMETER IpAddress

--- a/Scripts/Python/get_identitypool_usage.py
+++ b/Scripts/Python/get_identitypool_usage.py
@@ -1,0 +1,205 @@
+#
+#  Python script using OME API to get device list.
+#
+# _author_ = Trevor Squillario <Trevor.Squillario@Dell.com>
+# _version_ = 0.1
+#
+#
+# Copyright (c) 2018 Dell EMC Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+SYNOPSIS:
+   Script to get the list of devices managed by OM Enterprise
+
+DESCRIPTION:
+   This script exercises the OME REST API to get a list of devices
+   currently being managed by that instance. For authentication X-Auth
+   is used over Basic Authentication
+   Note that the credentials entered are not stored to disk.
+
+EXAMPLE:
+   python get_device_list.py --ip <xx> --user <username> --password <pwd>
+"""
+
+import sys
+import argparse
+from argparse import RawTextHelpFormatter
+import json
+import requests
+import urllib3
+import os
+import csv
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+session_auth_token = {}
+
+def get_session(ip_address, user_name, password):
+    session_url = 'https://%s/api/SessionService/Sessions' % (ip_address)
+    base_uri = 'https://%s' %(ip_address)
+    headers = {'content-type': 'application/json'}
+    user_details = {'UserName': user_name,
+                    'Password': password,
+                    'SessionType': 'API'}
+    session_info = requests.post(session_url, verify=False,
+                                    data=json.dumps(user_details),
+                                    headers=headers)
+    if session_info.status_code == 201:
+        session_info_token = session_info.headers['X-Auth-Token']
+        session_info_data = session_info.json()
+        session_auth_token = {
+            "token": session_info_token,
+            "id": session_info_data['Id']
+        }
+    return session_auth_token
+
+def delete_session(ip_address, headers, id):
+    session_url = "https://%s/api/SessionService/Sessions('%s')" % (ip_address, id)
+    print("Deleting Session %s" %(id))
+    session_info = requests.delete(session_url, verify=False, headers=headers)
+    if session_info.status_code == 201:
+        return True
+    else: 
+        return False
+
+def get_device_list(ip_address, user_name, password, identitypool_id, outfile):
+    """ Authenticate with OME and enumerate devices """
+    try:
+        base_uri = 'https://%s' %(ip_address)
+        next_link_url = None
+        headers = {'content-type': 'application/json'}
+
+        auth_token = get_session(ip_address, user_name, password)
+        if auth_token != None:
+            headers['X-Auth-Token'] = auth_token['token']
+
+            # Display Identity Pools
+            identitypool_url = base_uri + '/api/IdentityPoolService/IdentityPools'
+            identitypool_response = requests.get(identitypool_url, headers=headers, verify=False)
+            if identitypool_response.status_code == 200:
+                identitypool_data = identitypool_response.json()
+                identitypool_data = identitypool_data['value']
+                #device_count = identitypool_data['@odata.count']
+                #if device_count > 0:
+                for i in identitypool_data:
+                    print("Id: %s, Name: %s" %(i["Id"], i["Name"]))
+            else:
+                print("Unable to retrieve device list from %s" % (ip_address))
+
+            if identitypool_id == None:
+                identitypool_id_prompt = input("Please Enter Identity Pool Id: ")
+                identitypool_id = identitypool_id_prompt
+
+            # Get Identity Pool Usage Sets
+            identitypool_usageset_url = base_uri + "/api/IdentityPoolService/IdentityPools(%s)/UsageIdentitySets" % (identitypool_id)
+            identitypool_usageset_response = requests.get(identitypool_usageset_url, headers=headers, verify=False)
+            if identitypool_usageset_response.status_code == 200:
+                identitypool_usageset_data = identitypool_usageset_response.json()
+                identitypool_usageset_data = identitypool_usageset_data['value']
+                
+                detailentries = []
+                for usageset in identitypool_usageset_data:
+                    usageset_id = usageset["IdentitySetId"]
+                    usageset_name = usageset["Name"]
+
+                    identitypool_usageset_detail_url = base_uri + "/api/IdentityPoolService/IdentityPools(%s)/UsageIdentitySets(%s)/Details" % (identitypool_id, usageset_id)
+                    identitypool_usageset_detail_response = requests.get(identitypool_usageset_detail_url, headers=headers, verify=False)
+                    if identitypool_usageset_detail_response.status_code == 200:
+                        identitypool_usageset_detail_json = identitypool_usageset_detail_response.json()
+                        identitypool_usageset_detail_data = identitypool_usageset_detail_json['value']
+                        for detailentry in identitypool_usageset_detail_data:
+                            entry = {
+                                "IdentityType": usageset_name,
+                                "ChassisName": detailentry["DeviceInfo"]["ChassisName"],
+                                "ServerName": detailentry["DeviceInfo"]["ServerName"],
+                                "ManagementIp": detailentry["DeviceInfo"]["ManagementIp"],
+                                "NicIdentifier": detailentry["NicIdentifier"],
+                                "MacAddress": detailentry["MacAddress"]
+                            }
+                            detailentries.append(entry)
+                        
+                        if '@odata.nextLink' in identitypool_usageset_detail_json:
+                            next_link_url = base_uri + identitypool_usageset_detail_json['@odata.nextLink']
+                            while next_link_url:
+                                next_link_response = requests.get(next_link_url, headers=headers, verify=False)
+                                if next_link_response.status_code == 200:
+                                    next_link_json = next_link_response.json()
+                                    next_link_json_data += next_link_json['value']
+                                    for detailentry in next_link_json_data:
+                                        entry = {
+                                            "IdentityType": usageset_name,
+                                            "ChassisName": detailentry["DeviceInfo"]["ChassisName"],
+                                            "ServerName": detailentry["DeviceInfo"]["ServerName"],
+                                            "ManagementIp": detailentry["DeviceInfo"]["ManagementIp"],
+                                            "NicIdentifier": detailentry["NicIdentifier"],
+                                            "MacAddress": detailentry["MacAddress"]
+                                        }
+                                        detailentries.append(entry)
+                                    
+                                    if '@odata.nextLink' in next_link_json:
+                                        next_link_url = base_uri + next_link_json['@odata.nextLink']
+                                    else:
+                                        next_link_url = None
+                            else:
+                                print("Unable to retrieve items from nextLink %s" % (next_link_url))
+
+                # Export results to CSV
+                if (len(detailentries) > 0):
+                    print(json.dumps(detailentries, indent=2))
+
+                    currentDirectory = os.path.dirname(os.path.abspath(__file__))
+                    if outfile == None:
+                        outFilePath = currentDirectory + os.path.sep + "IdentityPoolUsage.csv"                        
+                    else:
+                        outFilePath = outfile                        
+                    outputFile = open(outFilePath, 'w') 
+                    output = csv.writer(outputFile) 
+                    output.writerow(detailentries[0].keys()) 
+                    for row in detailentries:
+                        output.writerow(row.values())
+                    print("Exported data to %s" %(outFilePath))
+                    outputFile.close()
+                else:
+                    print("No data to display")
+            else:
+                print("Unable to retrieve list from %s" % (ip_address))
+
+        else:
+            print("Unable to create a session with appliance %s" % (ip_address))
+    except:
+        print ("Unexpected error:", sys.exc_info())
+    finally:
+        delete_session(ip_address, headers, auth_token['id'])
+
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=RawTextHelpFormatter)
+    PARSER.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
+    PARSER.add_argument("--user", "-u", required=True,
+                        help="Username for OME Appliance", default="admin")
+    PARSER.add_argument("--password", "-p", required=True,
+                        help="Password for OME Appliance")
+    PARSER.add_argument("--id", required=False,
+                        help="Identity Pool Id")
+    PARSER.add_argument("--outfile", "-o", required=False,
+                        help="Full path to CSV file")
+
+    ARGS = PARSER.parse_args()
+
+
+    get_device_list(ARGS.ip, ARGS.user, ARGS.password, ARGS.id, ARGS.outfile)

--- a/Scripts/Python/get_identitypool_usage.py
+++ b/Scripts/Python/get_identitypool_usage.py
@@ -1,5 +1,5 @@
 #
-#  Python script using OME API to get device list.
+#  Python script to get the list of virtual addresses in an Identity Pool
 #
 # _author_ = Trevor Squillario <Trevor.Squillario@Dell.com>
 # _version_ = 0.1
@@ -22,16 +22,18 @@
 
 """
 SYNOPSIS:
-   Script to get the list of devices managed by OM Enterprise
+   Script to get the list of virtual addresses in an Identity Pool
 
 DESCRIPTION:
-   This script exercises the OME REST API to get a list of devices
-   currently being managed by that instance. For authentication X-Auth
-   is used over Basic Authentication
+   This script exercises the OME REST API to get a list of virtual addresses in an Identity Pool.
+   Will export to a CSV file called IdentityPoolUsage.csv in the current directory. 
+   For authentication X-Auth is used over Basic Authentication
    Note that the credentials entered are not stored to disk.
 
 EXAMPLE:
-   python get_device_list.py --ip <xx> --user <username> --password <pwd>
+   python get_identitypool_usage.py --ip <xx> --user <username> --password <pwd>
+   python get_identitypool_usage.py --ip <xx> --user <username> --password <pwd> --id 11
+   python get_identitypool_usage.py --ip <xx> --user <username> --password <pwd> --id 11 --outfile "/tmp/temp.csv"
 """
 
 import sys
@@ -93,8 +95,6 @@ def get_device_list(ip_address, user_name, password, identitypool_id, outfile):
             if identitypool_response.status_code == 200:
                 identitypool_data = identitypool_response.json()
                 identitypool_data = identitypool_data['value']
-                #device_count = identitypool_data['@odata.count']
-                #if device_count > 0:
                 for i in identitypool_data:
                     print("Id: %s, Name: %s" %(i["Id"], i["Name"]))
             else:
@@ -200,6 +200,5 @@ if __name__ == '__main__':
                         help="Full path to CSV file")
 
     ARGS = PARSER.parse_args()
-
 
     get_device_list(ARGS.ip, ARGS.user, ARGS.password, ARGS.id, ARGS.outfile)


### PR DESCRIPTION
Tested against OME 3.3.1 and OMEM 1.10.10. 

Scripts will list the current Identity Pools allowing the user to choose one or they can specify the Identity Pool Id with the `--id/-Id` parameter. This will then list all of the reserved virtual identities for the pool. Will dump a csv to current directory, this can be overridden with the `--outfile/-OutFile` parameter