### PR TITLE
get_device_inventory.py: Fix typeo in example

### DIFF
--- a/Core/Python/get_device_inventory.py
+++ b/Core/Python/get_device_inventory.py
@@ -32,7 +32,7 @@ DESCRIPTION:
 
 EXAMPLE:
     python get_device_inventory.py -i <ip addr> -u admin
-        -p <password> -fby Name -f "iDRAC-abcdef" -inventorytype os
+        -p <password> -fby Name -f "iDRAC-abcdef" -invtype os
 
 """
 import sys


### PR DESCRIPTION
- Fixed minor typeo in the shorthand used in the example.

Signed-off-by grant_curell@dell.com