### PR TITLE
Update PowerShell style - various minor fixes

### DIFF
--- a/Core/PowerShell/Create-McmGroup.ps1
+++ b/Core/PowerShell/Create-McmGroup.ps1
@@ -69,7 +69,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 }
@@ -80,7 +80,7 @@ function Get-DiscoveredDomains($IpAddress, $Headers, $Role) {
     $FilteredDiscoveredDomains = @()
     $TargetArray = @()
     $URL = "https://$($IpAddress)/api/ManagementDomainService/DiscoveredDomains"
-    $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -102,8 +102,8 @@ function Get-DiscoveredDomains($IpAddress, $Headers, $Role) {
         }
     }
 
-    if ($FilteredDiscoveredDomains.Length -gt 0){
-        foreach ($Domain in $FilteredDiscoveredDomains){
+    if ($FilteredDiscoveredDomains.Length -gt 0) {
+        foreach ($Domain in $FilteredDiscoveredDomains) {
             $TargetTempHash = @{}
             $TargetTempHash."GroupId" = $Domain."GroupId"
             $TargetArray += $TargetTempHash
@@ -151,7 +151,7 @@ function Create-McmGroup($IpAddress, $Headers, $GroupName) {
     $JobId = 0
     $Payload."GroupName" = $GroupName
     $Body = $payload | ConvertTo-Json -Depth 6
-    $Response = Invoke-WebRequest -Uri $CreateGroupURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method PUT -Body $Body 
+    $Response = Invoke-WebRequest -Uri $CreateGroupURL -Headers $Headers -ContentType $Type -Method PUT -Body $Body 
     if ($Response.StatusCode -eq 200) {
         $GroupData = $Response | ConvertFrom-Json
         $JobId = $GroupData.'JobId'
@@ -172,13 +172,13 @@ function Add-AllMembersViaLead($IpAddress, $Headers) {
     $StandaloneDomains = Get-DiscoveredDomains $IpAddress $Headers $Role
     $JobId = 0
     $Payload = @()
-    if ($StandaloneDomains.Length -gt 0){
+    if ($StandaloneDomains.Length -gt 0) {
         $Payload = $StandaloneDomains
         $ManagementDomainURL = "https://$($IpAddress)/api/ManagementDomainService/Actions/ManagementDomainService.Domains"
         $Body = $Payload 
         Write-Host "Adding members to the group..."
         Write-Host "Invoking URL $($ManagementDomainURL)"
-        $Response = Invoke-WebRequest -Uri $ManagementDomainURL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -Uri $ManagementDomainURL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $ManagementData = $Response | ConvertFrom-Json
             $JobId = $ManagementData.'JobId'
@@ -187,7 +187,8 @@ function Add-AllMembersViaLead($IpAddress, $Headers) {
         else {
             Write-Warning "Failed to add members to the group"
         }
-    } else {
+    }
+    else {
         Write-Warning "No standalone chassis found to add as member to the created group"
     }
     return $JobId
@@ -209,7 +210,7 @@ function Assign-BackupLead($IpAddress, $Headers) {
         Write-Host "Assigning backup lead..."
         Write-Host "Invoking URL $($URL)"
         Write-Host "Payload $($Body)"
-        $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $BackupLeadData = $Response | ConvertFrom-Json
             $JobId = $BackupLeadData.'JobId'
@@ -227,7 +228,7 @@ function Get-Domains($IpAddress, $Headers) {
     $Members = @()
     $ListOfMembers = @()
     $URL = "https://$($IpAddress)/api/ManagementDomainService/Domains"
-    $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -274,7 +275,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -UseBasicParsing -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -287,12 +288,12 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -UseBasicParsing -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -UseBasicParsing -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -307,7 +308,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             }
             else { continue }
         }
-        else {Write-Warning "Unable to get status for $($JobId) .. Iteration $($Ctr)"}
+        else { Write-Warning "Unable to get status for $($JobId) .. Iteration $($Ctr)" }
     } until ($Ctr -ge $MAX_RETRIES)
 }
 
@@ -321,7 +322,7 @@ Try {
     $Type = "application/json"
     $UserName = $Credentials.username
     $Password = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API"} | ConvertTo-Json
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
 
 
@@ -347,7 +348,8 @@ Try {
                 if ($JobId) {
                     Write-Host "Polling backup lead assignment ..."
                     Wait-OnJobStatus $IpAddress $Headers $Type $JobId
-                }else {
+                }
+                else {
                     Write-Warning "Unable to track backup lead assignment ..."
                 }
             }
@@ -360,6 +362,6 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/Get-ChassisInventory.ps1
+++ b/Core/PowerShell/Get-ChassisInventory.ps1
@@ -24,10 +24,6 @@
    In this instance you will be prompted for credentials to use
 #>
 
-
-
-
-
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)]
@@ -38,11 +34,10 @@ param(
 )
 
 
-
 function Set-CertPolicy() {
     ## Trust all certs - for sample usage only
     Try {
-    add-type @"
+        add-type @"
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -53,305 +48,321 @@ function Set-CertPolicy() {
         }
     }
 "@
-            [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        }
-        Catch {
-            Write-Error "Unable to add type for cert policy"
-        }
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
+    catch {
+        Write-Error "Unable to add type for cert policy"
+    }
+}
 
-    function Get-ManagedDeviceCount($IpAddress, $Headers, $Type){
-        Try{
-            $Count = 0
-            $CountUrl = "https://$($IpAddress)/api/DeviceService/Devices"+"?`$count=true&`$top=0"
-            Write-Host "Determining number of managed devices ..."
-            $CountResp = Invoke-WebRequest -Uri $CountUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            if( $CountResp.StatusCode -eq 200){
-                $CountInfo = $CountResp.Content|ConvertFrom-Json
-                $Count = $CountInfo.'@odata.count'
-                Write-Host "Total managed device count : $($Count)"
+function Get-ManagedDeviceCount($IpAddress, $Headers, $Type) {
+    Try {
+        $Count = 0
+        $CountUrl = "https://$($IpAddress)/api/DeviceService/Devices" + "?`$count=true&`$top=0"
+        Write-Host "Determining number of managed devices ..."
+        $CountResp = Invoke-WebRequest -Uri $CountUrl -Method Get -Headers $Headers -ContentType $Type
+        if ( $CountResp.StatusCode -eq 200) {
+            $CountInfo = $CountResp.Content | ConvertFrom-Json
+            $Count = $CountInfo.'@odata.count'
+            Write-Host "Total managed device count : $($Count)"
 
-            }else{
-                Write-Host "*** ERROR: Unable to retrieve device count from $($IpAddress)"
+        }
+        else {
+            Write-Host "*** ERROR: Unable to retrieve device count from $($IpAddress)"
+        }
+
+    }
+    catch {
+        Write-Error "Exception occured - $($_.Exception.Message)"
+    }
+    return $Count
+}
+
+function Get-NonServerMacAddress($DeviceInfo) {
+    $DeviceMgmtAddresses = @{}
+    Try {
+        $MgmtInfo = $DeviceInfo.'DeviceManagement' 
+
+        if ($MgmtInfo) {
+            $MgmtCount = 1
+            foreach ($MgmtNode in $MgmtInfo) {
+                if ($MgmtNode.'MacAddress') {
+                    $CurrentMac = "System_MAC_" + [string] $MgmtCount
+                    $DeviceMgmtAddresses.$CurrentMac = [string] $MgmtNode.'MacAddress'
+                    $MgmtCount = $MgmtCount + 1
+                } 
             }
-
-        }catch{
-            Write-Error "Exception occured - $($_.Exception.Message)"
         }
-        return $Count
     }
-
-    function Get-NonServerMacAddress($DeviceInfo){
-        $DeviceMgmtAddresses = @{}
-        Try{
-            $MgmtInfo = $DeviceInfo.'DeviceManagement' 
-
-            if($MgmtInfo){
-                $MgmtCount = 1
-                foreach($MgmtNode in $MgmtInfo){
-                    if($MgmtNode.'MacAddress'){
-                        $CurrentMac = "System_MAC_" + [string] $MgmtCount
-                        $DeviceMgmtAddresses.$CurrentMac =[string] $MgmtNode.'MacAddress'
-                        $MgmtCount = $MgmtCount+1
-                    } 
-                }
-            }
-        }catch{
-            Write-Error "Exception occured - $($_.Exception.Message)"
-        }
-        return $DeviceMgmtAddresses
-
+    catch {
+        Write-Error "Exception occured - $($_.Exception.Message)"
     }
+    return $DeviceMgmtAddresses
+
+}
 
     
 
-    function  Write-OutputCsvFile ($CsvData, $CsvColumns){
-        $CsvFile = "chassis_inventory.csv"
-        Try{
-            if([System.IO.File]::Exists($CsvFile)){
-                Remove-Item $CsvFile
-            }
-            $user = new-object psobject -property $CsvData
-            $columnName = [system.String]::Join(",", $CsvColumns)
-            Add-Content -Path $CsvFile -Value $columnName
-            $user.psObject.properties|ForEach-Object{
-                $value =$_.value
+function  Write-OutputCsvFile ($CsvData, $CsvColumns) {
+    $CsvFile = "chassis_inventory.csv"
+    Try {
+        if ([System.IO.File]::Exists($CsvFile)) {
+            Remove-Item $CsvFile
+        }
+        $user = new-object psobject -property $CsvData
+        $columnName = [system.String]::Join(",", $CsvColumns)
+        Add-Content -Path $CsvFile -Value $columnName
+        $user.psObject.properties | ForEach-Object {
+            $value = $_.value
                 
-               foreach($val in $value){
+            foreach ($val in $value) {
                 $keys = @()
-                foreach($key in $val.Keys){
-                    $keys +=$key 
+                foreach ($key in $val.Keys) {
+                    $keys += $key 
                 }
-                 $item= $null
-               for($i = 0;$i -lt $CsvColumns.length;$i++){
-                    if($Keys -Contains $CsvColumns[$i] ){
-                       $item += $val[$CsvColumns[$i]]
-                    }else{
+                $item = $null
+                for ($i = 0; $i -lt $CsvColumns.length; $i++) {
+                    if ($Keys -Contains $CsvColumns[$i] ) {
+                        $item += $val[$CsvColumns[$i]]
+                    }
+                    else {
                         $item += ""
                     }
-                    if($i -ne $CsvColumns.length-1){
-                        $item= $item+","
+                    if ($i -ne $CsvColumns.length - 1) {
+                        $item = $item + ","
                     }
                 }
                 Add-Content -Path $CsvFile -Value  $item
             }
-                }
-                 write-Host "Completed writing output to file chassis_inventory.csv"
-        }catch{
-            Write-Error "Exception occured - $($_.Exception.Message)"
         }
-
-
+        write-Host "Completed writing output to file chassis_inventory.csv"
     }
+    catch {
+        Write-Error "Exception occured - $($_.Exception.Message)"
+    }
+}
 
-    function Get-ServerMacAddress ($DeviceInfo, $IpAddress, $Headers, $Type){
-        $DeviceMgmtAddresses = @{}
-        Try{
-            write-Host "Determining BMC MAC address information ..."
-            $MgmtInfo = $DeviceInfo.'DeviceManagement'
-            if($MgmtInfo){
-                $MacCount = 1
-                foreach($MgmtNode in $MgmtInfo){
-                    if($MgmtNode.'MacAddress'){
-                        $CurrentMac = "BMC_MAC_" +[string]$MacCount
-                        $DeviceMgmtAddresses.$CurrentMac = [string] $MgmtNode.'MacAddress'
-                        $MacCount = $MacCount +1
-                        break
-                    }
-
+function Get-ServerMacAddress ($DeviceInfo, $IpAddress, $Headers, $Type) {
+    $DeviceMgmtAddresses = @{}
+    Try {
+        write-Host "Determining BMC MAC address information ..."
+        $MgmtInfo = $DeviceInfo.'DeviceManagement'
+        if ($MgmtInfo) {
+            $MacCount = 1
+            foreach ($MgmtNode in $MgmtInfo) {
+                if ($MgmtNode.'MacAddress') {
+                    $CurrentMac = "BMC_MAC_" + [string]$MacCount
+                    $DeviceMgmtAddresses.$CurrentMac = [string] $MgmtNode.'MacAddress'
+                    $MacCount = $MacCount + 1
+                    break
                 }
             }
-            $DeviceId = [string]$DeviceInfo.'Id'
-            $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
-            $DeviceInventoryUrl = $DeviceUrl +"($($DeviceId))/InventoryDetails('serverNetworkInterfaces')"
-            Try{
-                $DeviceInventoryResp = Invoke-WebRequest -Uri $DeviceInventoryUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-            }catch{
-                $err=$_.Exception
-                $err | Get-Member -MemberType Property
-            }
-            if($DeviceInventoryResp.StatusCode -eq 200){
-                $DeviceInventoryInfo = $DeviceInventoryResp.Content | ConvertFrom-Json
-                if($DeviceInventoryInfo.'InventoryInfo'.length -gt 0){
-                    foreach($NicInfo in $DeviceInventoryInfo.'InventoryInfo'){
-                        $MacCount =1
-                       foreach($NicData in $NicInfo.'Ports'){
-                            $CurrentMac = "System_MAC_" +[string]$MacCount
-                            $FullProductName = [string] $NicData.'ProductName'
-                            Write-Host "Analyzing $($FullProductName)"
-                            if($FullProductName.Contains("-")){
-                                 $MacAddr = $FullProductName.Split('-')[-1]
-                                $DeviceMgmtAddresses.$CurrentMac = $MacAddr
-                                $MacCount = $MacCount +1
+        }
+        $DeviceId = [string]$DeviceInfo.'Id'
+        $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
+        $DeviceInventoryUrl = $DeviceUrl + "($($DeviceId))/InventoryDetails('serverNetworkInterfaces')"
+        Try {
+            $DeviceInventoryResp = Invoke-WebRequest -Uri $DeviceInventoryUrl -Method Get -Headers $Headers -ContentType $Type
+        }
+        catch {
+            $err = $_.Exception
+            $err | Get-Member -MemberType Property
+        }
+        if ($DeviceInventoryResp.StatusCode -eq 200) {
+            $DeviceInventoryInfo = $DeviceInventoryResp.Content | ConvertFrom-Json
+            if ($DeviceInventoryInfo.'InventoryInfo'.length -gt 0) {
+                foreach ($NicInfo in $DeviceInventoryInfo.'InventoryInfo') {
+                    $MacCount = 1
+                    foreach ($NicData in $NicInfo.'Ports') {
+                        $CurrentMac = "System_MAC_" + [string]$MacCount
+                        $FullProductName = [string] $NicData.'ProductName'
+                        Write-Host "Analyzing $($FullProductName)"
+                        if ($FullProductName.Contains("-")) {
+                            $MacAddr = $FullProductName.Split('-')[-1]
+                            $DeviceMgmtAddresses.$CurrentMac = $MacAddr
+                            $MacCount = $MacCount + 1
 
-                            }else{
-                                foreach($NicPartition in $NicData.'Partitions'){
-                                    if($NicPartition.'CurrentMacAddress'){
-                                        $MacAddr = $NicPartition.'CurrentMacAddress'
-                                        $DeviceMgmtAddresses.$CurrentMac = $MacAddr
-                                        $MacCount = $MacCount+1
-                                    }
+                        }
+                        else {
+                            foreach ($NicPartition in $NicData.'Partitions') {
+                                if ($NicPartition.'CurrentMacAddress') {
+                                    $MacAddr = $NicPartition.'CurrentMacAddress'
+                                    $DeviceMgmtAddresses.$CurrentMac = $MacAddr
+                                    $MacCount = $MacCount + 1
                                 }
                             }
                         }
                     }
-                }else{
-                    Write-Host "*** ERROR: No network inventory info returned for $($DeviceInfo.'DeviceServiceTag')"
-                } 
-            }else{
-                Write-Host "*** WARN: No network inventory info returned for $($DeviceInfo.'DeviceServiceTag')"
+                }
             }
-        }catch{
-            Write-Error "Exception occured - $($_.Exception.Message)"
+            else {
+                Write-Host "*** ERROR: No network inventory info returned for $($DeviceInfo.'DeviceServiceTag')"
+            } 
         }
-      
-        return $DeviceMgmtAddresses
-
+        else {
+            Write-Host "*** WARN: No network inventory info returned for $($DeviceInfo.'DeviceServiceTag')"
+        }
     }
+    catch {
+        Write-Error "Exception occured - $($_.Exception.Message)"
+    }
+      
+    return $DeviceMgmtAddresses
+}
 
-    function Get-DeviceInventory($IpAddress, $Headers, $Type){
-        Try{
-            $CsvColumns = @('Hostname', 'Unit', 'SerialNumber', 'System_MAC_1',
+function Get-DeviceInventory($IpAddress, $Headers, $Type) {
+    Try {
+        $CsvColumns = @('Hostname', 'Unit', 'SerialNumber', 'System_MAC_1',
             'System_MAC_2', 'System_MAC_3', 'System_MAC_4',
             'System_MAC_5', 'System_MAC_6', 'System_MAC_7',
             'System_MAC_8', 'BMC_MAC_1', 'Chassis',
             'Chassis_Location', 'Model')
-            $UnitMap = @{"1000"= "System"; "2000"="Chassis";
-            "3000"="Storage"; "4000"= "Switch";
-            "8000"= "Storage-IOM"}
-            $CsvData = @{}
-            $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
-            $DeviceCount = Get-ManagedDeviceCount $IpAddress $Headers $Type
-            if($DeviceCount -gt 0){
-                $AllDeviceUrl = $DeviceUrl + "?`$skip=0&`$top=$($DeviceCount)"
-                Write-Host "Enumerating all device info ..."
-                $AllDeviceResp = Invoke-WebRequest -Uri $AllDeviceUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                if($AllDeviceResp.StatusCode -eq 200){
-                    $AllDeviceInfo = $AllDeviceResp.Content|ConvertFrom-Json
-                    Write-Host "Iterating through devices and correlating data ..."
-                    foreach($DeviceInfo in $AllDeviceInfo.'value'){
-                        $DeviceId = $DeviceInfo.'Id'
-                        $DeviceType =[string]$DeviceInfo.'Type'
-                        $DeviceUnitName = $null
-                        if ($UnitMap.ContainsKey($DeviceType)) {
-                            $DeviceUnitName = $UnitMap.$DeviceType
-                        }
-                        $DeviceModel = $null
-                        if($DeviceInfo.'Model'){
-                            $DeviceModel = [string]$DeviceInfo.'Model'
-                        }
-                        $DeviceSvcTag = $null
-                        if($DeviceInfo.'DeviceServiceTag'){
-                            $DeviceSvcTag = [string]$DeviceInfo.'DeviceServiceTag'
-                        }
-                        $DeviceHostName = $null
-                        if($DeviceInfo.'DeviceName'){
-                            $DeviceHostName = [string]$DeviceInfo.'DeviceName'
-                        }
-                        Write-Host "Processing ID:$($DeviceId), Type:$($DeviceUnitName),Model:$($DeviceModel),SvcTag:$($DeviceSvcTag),Host:$($DeviceHostName)"
+        $UnitMap = @{"1000" = "System"; "2000" = "Chassis";
+            "3000" = "Storage"; "4000" = "Switch";
+            "8000" = "Storage-IOM"
+        }
+        $CsvData = @{}
+        $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
+        $DeviceCount = Get-ManagedDeviceCount $IpAddress $Headers $Type
+        if ($DeviceCount -gt 0) {
+            $AllDeviceUrl = $DeviceUrl + "?`$skip=0&`$top=$($DeviceCount)"
+            Write-Host "Enumerating all device info ..."
+            $AllDeviceResp = Invoke-WebRequest -Uri $AllDeviceUrl -Method Get -Headers $Headers -ContentType $Type
+            if ($AllDeviceResp.StatusCode -eq 200) {
+                $AllDeviceInfo = $AllDeviceResp.Content | ConvertFrom-Json
+                Write-Host "Iterating through devices and correlating data ..."
+                foreach ($DeviceInfo in $AllDeviceInfo.'value') {
+                    $DeviceId = $DeviceInfo.'Id'
+                    $DeviceType = [string]$DeviceInfo.'Type'
+                    $DeviceUnitName = $null
+                    if ($UnitMap.ContainsKey($DeviceType)) {
+                        $DeviceUnitName = $UnitMap.$DeviceType
+                    }
+                    $DeviceModel = $null
+                    if ($DeviceInfo.'Model') {
+                        $DeviceModel = [string]$DeviceInfo.'Model'
+                    }
+                    $DeviceSvcTag = $null
+                    if ($DeviceInfo.'DeviceServiceTag') {
+                        $DeviceSvcTag = [string]$DeviceInfo.'DeviceServiceTag'
+                    }
+                    $DeviceHostName = $null
+                    if ($DeviceInfo.'DeviceName') {
+                        $DeviceHostName = [string]$DeviceInfo.'DeviceName'
+                    }
+                    Write-Host "Processing ID:$($DeviceId), Type:$($DeviceUnitName),Model:$($DeviceModel),SvcTag:$($DeviceSvcTag),Host:$($DeviceHostName)"
                          
                         
-                        ## Assemble device dictionary info
-                        $TempHash = @{}
-                        $TempHash.'Model' =$DeviceModel
-                        $TempHash.'SerialNumber' =$DeviceSvcTag
-                        $TempHash.'Hostname' = $DeviceHostName
-                        $TempHash.'Unit' = $DeviceUnitName
-                        if( $DeviceUnitName){
-                            $MacAddress = @{}
-                            if($DeviceUnitName -eq "Chassis"){
-                                if($DeviceSvcTag){
-                                    if (!$CsvData.ContainsKey($DeviceSvcTag)){
-                                       $CsvData.$DeviceSvcTag = @()
+                    ## Assemble device dictionary info
+                    $TempHash = @{}
+                    $TempHash.'Model' = $DeviceModel
+                    $TempHash.'SerialNumber' = $DeviceSvcTag
+                    $TempHash.'Hostname' = $DeviceHostName
+                    $TempHash.'Unit' = $DeviceUnitName
+                    if ( $DeviceUnitName) {
+                        $MacAddress = @{}
+                        if ($DeviceUnitName -eq "Chassis") {
+                            if ($DeviceSvcTag) {
+                                if (!$CsvData.ContainsKey($DeviceSvcTag)) {
+                                    $CsvData.$DeviceSvcTag = @()
+                                }
+                            }
+                            else {
+                                Write-Host "*** WARNING: Chassis service tag is NULL..."
+                            }
+                            $MacAddress = Get-NonServerMacAddress $DeviceInfo
+                            foreach ($MacAddr in $MacAddress.keys) {
+                                $TempHash.$MacAddr = $MacAddress.$MacAddr
+                            }
+                            $CsvData.$DeviceSvcTag += $TempHash  
+                        }
+                        else {
+                            $ChassisSvcTag = $null
+                            if ($DeviceInfo.'ChassisServiceTag') {
+                                $ChassisSvcTag = [string]$DeviceInfo.'ChassisServiceTag'
+                            }
+                            else {
+                                Write-Host "Warning...Chassis service tag is Null"
+                            }
+                            $TempHash.'Chassis' = $ChassisSvcTag
+                            $SlotFound = $false
+                            foreach ($item in $DeviceInfo.psObject.properties) {
+                                if ($item.Name -eq 'SlotConfiguration') {
+                                    if ([string]$item.Value -ne '') {
+                                        $SlotFound = $true
+                                        $slotConfig = $item.Value
+                                        foreach ($slotItem in $slotConfig.psObject.properties) {
+                                            if ([string]$slotItem.Name -eq 'SlotName') {
+                                                $TempHash.'Chassis_Location' = $slotItem.Value 
+                                            }
+                                        }
                                     }
-                                }else{
-                                    Write-Host "*** WARNING: Chassis service tag is NULL..."
                                 }
+                            }
+                            if (!$SlotFound) {
+                                Write-Host("*** WARNING: No slot configuration information available ")
+                            }
+                            if ($DeviceUnitName -ne "System") {
                                 $MacAddress = Get-NonServerMacAddress $DeviceInfo
-                                foreach($MacAddr in $MacAddress.keys){
-                                    $TempHash.$MacAddr = $MacAddress.$MacAddr
-                                }
-                                $CsvData.$DeviceSvcTag +=$TempHash  
-                            }else{
-                                $ChassisSvcTag = $null
-                                if($DeviceInfo.'ChassisServiceTag'){
-                                    $ChassisSvcTag = [string]$DeviceInfo.'ChassisServiceTag'
-                                }else{
-                                    Write-Host "Warning...Chassis service tag is Null"
-                                }
-                                $TempHash.'Chassis' = $ChassisSvcTag
-                                $SlotFound = $false
-                              foreach ($item in $DeviceInfo.psObject.properties) {
-                                  if($item.Name -eq 'SlotConfiguration'){
-                                      if([string]$item.Value -ne ''){
-                                          $SlotFound = $true
-                                          $slotConfig = $item.Value
-                                          foreach($slotItem in $slotConfig.psObject.properties){
-                                              if([string]$slotItem.Name -eq 'SlotName'){
-                                                  $TempHash.'Chassis_Location' = $slotItem.Value 
-                                              }
-                                          }
-                                      }
-                                  }
+                            }
+                            else {
+                                $MacAddress = Get-ServerMacAddress $DeviceInfo $IpAddress $Headers $Type
                                   
-                              }
-                              if(!$SlotFound){
-                                     Write-Host("*** WARNING: No slot configuration information available ")
+                            }
+                            foreach ($MacAddr in $MacAddress.Keys) {
+                                $TempHash.$MacAddr = $MacAddress.$MacAddr
+                            }
+                            if ($ChassisSvcTag) {
+                                if (! $CsvData.ContainsKey($ChassisSvcTag) ) {
+                                    $CsvData.$ChassisSvcTag = @()
                                 }
-                               if($DeviceUnitName -ne "System"){
-                                    $MacAddress = Get-NonServerMacAddress $DeviceInfo
-                                }else{
-                                    $MacAddress = Get-ServerMacAddress $DeviceInfo $IpAddress $Headers $Type
-                                  
-                                }
-                               foreach($MacAddr in $MacAddress.Keys){
-                                   $TempHash.$MacAddr = $MacAddress.$MacAddr
-                               }
-                                if($ChassisSvcTag){
-                                   if(! $CsvData.ContainsKey($ChassisSvcTag) ){
-                                       $CsvData.$ChassisSvcTag = @()
-                                   }
-                                   $CsvData.$ChassisSvcTag +=$TempHash
-                               }else{
+                                $CsvData.$ChassisSvcTag += $TempHash
+                            }
+                            else {
                                 Write-Host("*** WARNING: Unable to add ($($DeviceId),$($DeviceSvcTag)) - chassis_svc_tag is NULL")
-                               }    
-                          }
-                        }else{
-                            Write-Host "*** ERROR: Unable to find a mapping for device in unit map"
-                        }  
+                            }    
+                        }
                     }
-                    if($CsvData){
-                       
-                        Write-OutputCsvFile $CsvData  $CsvColumns
-                    }
-                }else{
-                    Write-Host "*** ERROR: Unable to retrieve all device info from $($IpAddress) .. Exiting"
+                    else {
+                        Write-Host "*** ERROR: Unable to find a mapping for device in unit map"
+                    }  
                 }
-            }else{
-                Write-Host "*** ERROR: No devices retrieved from $($IpAddress)"
+                if ($CsvData) {
+                       
+                    Write-OutputCsvFile $CsvData  $CsvColumns
+                }
             }
-        }catch{
-            Write-Error "Exception occured - $($_.Exception.Message)"
+            else {
+                Write-Host "*** ERROR: Unable to retrieve all device info from $($IpAddress) .. Exiting"
+            }
+        }
+        else {
+            Write-Host "*** ERROR: No devices retrieved from $($IpAddress)"
         }
     }
-
-    Try {
-        Set-CertPolicy
-        $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-        $Type        = "application/json"
-        $UserName    = $Credentials.username
-        $Password    = $Credentials.GetNetworkCredential().password
-        $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
-        $Headers     = @{}
-        $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
-        if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
-            $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-            Get-DeviceInventory $IpAddress $Headers $Type
-        }
-        else{
-            Write-Error "*** ERROR: Unable to authenticate with endpoint .. Check IP/Username/Pwd"
-        }
-    }catch {
+    catch {
         Write-Error "Exception occured - $($_.Exception.Message)"
     }
+}
+
+Try {
+    Set-CertPolicy
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
+    $Headers = @{}
+    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
+        $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
+        Get-DeviceInventory $IpAddress $Headers $Type
+    }
+    else {
+        Write-Error "*** ERROR: Unable to authenticate with endpoint .. Check IP/Username/Pwd"
+    }
+}
+catch {
+    Write-Error "Exception occured - $($_.Exception.Message)"
+}

--- a/Core/PowerShell/Get-DeviceInventory.ps1
+++ b/Core/PowerShell/Get-DeviceInventory.ps1
@@ -58,28 +58,28 @@ limitations under the License.
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
-    [System.Net.IPAddress] $IpAddress,
+  [Parameter(Mandatory)]
+  [System.Net.IPAddress] $IpAddress,
 
-    [Parameter(Mandatory)]
-    [pscredential] $Credentials,
+  [Parameter(Mandatory)]
+  [pscredential] $Credentials,
 
-    [Parameter(Mandatory)]
-    [ValidateSet("Name", "Id", "SvcTag")]
-    [String] $FilterBy,
+  [Parameter(Mandatory)]
+  [ValidateSet("Name", "Id", "SvcTag")]
+  [String] $FilterBy,
 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet("cpus","memory", "controllers", "disks","os")]
-    [String] $InventoryType,
+  [Parameter(Mandatory = $false)]
+  [ValidateSet("cpus", "memory", "controllers", "disks", "os")]
+  [String] $InventoryType,
 
-    [Parameter(Mandatory)]
-    [String] $DeviceInfo
+  [Parameter(Mandatory)]
+  [String] $DeviceInfo
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+  ## Trust all certs - for sample usage only
+  Try {
+    add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -90,73 +90,73 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
     }
 }
 "@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    Catch {
-        Write-Error "Unable to add type for cert policy"
-    }
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  }
+  catch {
+    Write-Error "Unable to add type for cert policy"
+  }
 }
 
 Try {
-    Set-CertPolicy
-    $FilterMap = @{'Name'='DeviceName'; 'Id'='Id'; 'SvcTag'='DeviceServiceTag'}
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $InventoryTypeMap = @{"cpus"="serverProcessors";"os"="serverOperatingSystems";"disks"="serverArrayDisks";"controllers"="serverRaidControllers";"memory" ="serverMemoryDevices"}
-    $FilterExpr  = $FilterMap[$FilterBy]
-    $BaseUrl     = "https://$($IpAddress)/api/DeviceService/Devices?`$filter=$($FilterExpr) eq"
-    $DevUrl      = ""
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
-    $Headers     = @{}
-    $DeviceId    = ""
-    if ($FilterBy -eq 'Id') {
-        $DevUrl = "$($BaseUrl) $($DeviceInfo)"
-    }
-    else {
-        $DevUrl = "$($BaseUrl) '$($DeviceInfo)'"
-    }
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
-    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
-        ## Successfully created a session - extract the auth token from the response
-        ## header and update our headers for subsequent requests
-        $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $DevResp = Invoke-WebRequest -Uri $DevUrl -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-        if ($DevResp.StatusCode -eq 200) {
-            $DevInfo = $DevResp.Content | ConvertFrom-Json
-            if ($DevInfo.'@odata.count' -gt 0) {
-                $DeviceId = $DevInfo.value[0].Id
-                $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails"
-                if($InventoryType){
-                    $InventoryUrl =  "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails('$($InventoryTypeMap[$InventoryType])')"
-                }
-                $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-                if ($InventoryResp.StatusCode -eq 200) {
-                    $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
-                  $InventoryDetails = $InventoryInfo | ConvertTo-Json -Depth 6
-                  Write-Host  $InventoryDetails
-                }
-                elseif($InventoryResp.StatusCode -eq 400){
-					Write-Warning "Inventory type $($InventoryType) not applicable for device id  $($DeviceId) "
-				}
-                else {
-                    Write-Warning "Unable to retrieve inventory for device $($DeviceId) due to status code ($($InventoryResp.StatusCode))"
-                }
-            }
-            else {
-                    Write-Warning "Unable to retrieve details for device ($($DeviceInfo)) from $($IpAddress)"
-            }
+  Set-CertPolicy
+  $FilterMap = @{'Name' = 'DeviceName'; 'Id' = 'Id'; 'SvcTag' = 'DeviceServiceTag' }
+  $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+  $InventoryTypeMap = @{"cpus" = "serverProcessors"; "os" = "serverOperatingSystems"; "disks" = "serverArrayDisks"; "controllers" = "serverRaidControllers"; "memory" = "serverMemoryDevices" }
+  $FilterExpr = $FilterMap[$FilterBy]
+  $BaseUrl = "https://$($IpAddress)/api/DeviceService/Devices?`$filter=$($FilterExpr) eq"
+  $DevUrl = ""
+  $Type = "application/json"
+  $UserName = $Credentials.username
+  $Password = $Credentials.GetNetworkCredential().password
+  $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
+  $Headers = @{}
+  $DeviceId = ""
+  if ($FilterBy -eq 'Id') {
+    $DevUrl = "$($BaseUrl) $($DeviceInfo)"
+  }
+  else {
+    $DevUrl = "$($BaseUrl) '$($DeviceInfo)'"
+  }
+  $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+  if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
+    ## Successfully created a session - extract the auth token from the response
+    ## header and update our headers for subsequent requests
+    $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
+    $DevResp = Invoke-WebRequest -Uri $DevUrl -Headers $Headers -Method Get -ContentType $Type
+    if ($DevResp.StatusCode -eq 200) {
+      $DevInfo = $DevResp.Content | ConvertFrom-Json
+      if ($DevInfo.'@odata.count' -gt 0) {
+        $DeviceId = $DevInfo.value[0].Id
+        $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails"
+        if ($InventoryType) {
+          $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails('$($InventoryTypeMap[$InventoryType])')"
+        }
+        $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -Headers $Headers -Method Get -ContentType $Type
+        if ($InventoryResp.StatusCode -eq 200) {
+          $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
+          $InventoryDetails = $InventoryInfo | ConvertTo-Json -Depth 6
+          Write-Host  $InventoryDetails
+        }
+        elseif ($InventoryResp.StatusCode -eq 400) {
+          Write-Warning "Inventory type $($InventoryType) not applicable for device id  $($DeviceId) "
         }
         else {
-            Write-Warning "No device data retrieved from from $($IpAddress)"
+          Write-Warning "Unable to retrieve inventory for device $($DeviceId) due to status code ($($InventoryResp.StatusCode))"
         }
+      }
+      else {
+        Write-Warning "Unable to retrieve details for device ($($DeviceInfo)) from $($IpAddress)"
+      }
     }
     else {
-        Write-Error "Unable to create a session with appliance $($IpAddress)"
+      Write-Warning "No device data retrieved from from $($IpAddress)"
     }
+  }
+  else {
+    Write-Error "Unable to create a session with appliance $($IpAddress)"
+  }
 }
-Catch {
-    Write-Error "Exception occured - $($_.Exception.Message)"
+catch {
+  Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/Get-GroupDetails.ps1
+++ b/Core/PowerShell/Get-GroupDetails.ps1
@@ -61,9 +61,9 @@ param(
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+    ## Trust all certs - for sample usage only
+    Try {
+        add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -77,7 +77,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 }
@@ -88,19 +88,19 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
 
 Try {
     Set-CertPolicy
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $GroupUrl    = "https://$($IpAddress)/api/GroupService/Groups"
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
-    $Headers     = @{}
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
+    $Headers = @{}
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $GrpResp = Invoke-WebRequest -Uri $GroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        $GrpResp = Invoke-WebRequest -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
         if ($GrpResp.StatusCode -eq 200) {
             ## Iterate over groups and see if a match is found for given criteria
             $GrpInfo = $GrpResp.Content | ConvertFrom-Json
@@ -109,12 +109,12 @@ Try {
             if ($groupCount -gt 0) {
                 $FoundGroup = $FALSE
                 $currGroupCount = ($groupList.value).Length
-                if($groupCount -gt $currGroupCount){
-                    $delta = $groupCount-$currGroupCount
-                    $RemainingGroupUrl = $GroupUrl+"?`$skip=$($currGroupCount)&`$top=$($delta)"
-                    $remainingGroupResp = Invoke-WebRequest -Uri $RemainingGroupUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                    if($remainingGroupResp.StatusCode -eq 200){
-                        $remGroupInfo = $remainingGroupResp.Content|ConvertFrom-Json
+                if ($groupCount -gt $currGroupCount) {
+                    $delta = $groupCount - $currGroupCount
+                    $RemainingGroupUrl = $GroupUrl + "?`$skip=$($currGroupCount)&`$top=$($delta)"
+                    $remainingGroupResp = Invoke-WebRequest -Uri $RemainingGroupUrl -Method Get -Headers $Headers -ContentType $Type
+                    if ($remainingGroupResp.StatusCode -eq 200) {
+                        $remGroupInfo = $remainingGroupResp.Content | ConvertFrom-Json
                         $groupList += $remGroupInfo.value
                     }
                 }
@@ -126,24 +126,24 @@ Try {
                         Write-Output "*** Group Details ***"
                         $Group | Format-List
                         $DevUrl = $GroupUrl + "(" + [String]($Group.Id) + ")/Devices"
-                        $DevResp = Invoke-WebRequest -Uri $DevUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                        $DevResp = Invoke-WebRequest -Uri $DevUrl -Method Get -Headers $Headers -ContentType $Type
                         if ($DevResp.StatusCode -eq 200) {
                             $DevInfo = $DevResp.Content | ConvertFrom-Json
                             $DevList = $DevInfo.value
                             $deviceCount = $DevInfo.'@odata.count'
                             if ($deviceCount -gt 0) {
                                 $currDeviceCount = ($DevInfo.value).Length
-                                if($deviceCount -gt $currDeviceCount){
-                                    $delta = $deviceCount-$currDeviceCount 
-                                    $RemainingDeviceurl = $DevUrl+"?`$skip=$($currDeviceCount)&`$top=$($delta)"
-                                    $RemainingDeviceResp = Invoke-WebRequest -Uri $RemainingDeviceurl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-                                    if($RemainingDeviceResp.StatusCode -eq 200){
-                                        $RemainingDeviceInfo = $RemainingDeviceResp.Content|ConvertFrom-Json
-                                        $DevList+=$RemainingDeviceInfo.value
+                                if ($deviceCount -gt $currDeviceCount) {
+                                    $delta = $deviceCount - $currDeviceCount 
+                                    $RemainingDeviceurl = $DevUrl + "?`$skip=$($currDeviceCount)&`$top=$($delta)"
+                                    $RemainingDeviceResp = Invoke-WebRequest -Uri $RemainingDeviceurl -Method Get -Headers $Headers -ContentType $Type
+                                    if ($RemainingDeviceResp.StatusCode -eq 200) {
+                                        $RemainingDeviceInfo = $RemainingDeviceResp.Content | ConvertFrom-Json
+                                        $DevList += $RemainingDeviceInfo.value
                                     }
                                     else {
                                         Write-Error "Unable to get full set of devices ... "
-                                      }
+                                    }
                                 }
 
                                 Write-Output "*** Group Device Details ***"
@@ -176,6 +176,6 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/Get-IdentityPoolUsage.ps1
+++ b/Core/PowerShell/Get-IdentityPoolUsage.ps1
@@ -60,17 +60,17 @@ param(
     [Parameter(Mandatory)]
     [pscredential] $Credentials,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [String] $Id,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [String] $OutFile
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+    ## Trust all certs - for sample usage only
+    Try {
+        add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -84,7 +84,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 }
@@ -92,26 +92,26 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
 $SessionAuthToken = @{}
 
 function Get-Session($IpAddress, $Credentials) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         $SessionAuthToken = @{
-        "token"= $SessResponse.Headers["X-Auth-Token"];
-        "id"= $SessResponseData.Id
+            "token" = $SessResponse.Headers["X-Auth-Token"];
+            "id"    = $SessResponseData.Id
         }
     }
     return $SessionAuthToken
 }
 
 function Remove-Session($IpAddress, $Headers, $Id) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
-    $Type        = "application/json"
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
+    $Type = "application/json"
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
 }
 
@@ -119,8 +119,8 @@ Try {
     Set-CertPolicy
     $BaseUri = "https://$($IpAddress)"
     $NextLinkUrl = $null
-    $Type        = "application/json"
-    $Headers     = @{}
+    $Type = "application/json"
+    $Headers = @{}
 
     # Request authentication session token
     $AuthToken = Get-Session $IpAddress $Credentials
@@ -130,7 +130,7 @@ Try {
         
         # Display Identity Pools
         $IdentityPoolUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools"
-        $IdentityPoolResp = Invoke-WebRequest -Uri $IdentityPoolUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        $IdentityPoolResp = Invoke-WebRequest -Uri $IdentityPoolUrl -Method Get -Headers $Headers -ContentType $Type
         if ($IdentityPoolResp.StatusCode -eq 200) {
             $IdentityPoolRespData = $IdentityPoolResp.Content | ConvertFrom-Json
             $IdentityPoolRespData = $IdentityPoolRespData.'value'
@@ -143,7 +143,7 @@ Try {
 
         # Get Identity Pool Usage Sets
         $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets"
-        $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -Method Get -Headers $Headers -ContentType $Type
         if ($IdentityPoolUsageSetResp.StatusCode -eq 200) {
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetRespData.'value'
@@ -155,52 +155,52 @@ Try {
                 $IdentitySetName = $IdentitySet.Name
 
                 $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets($($IdentitySetId))/Details"
-                $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($IdentityPoolUsageDetailResp.StatusCode -eq 200) {
                     $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json
                     # Loop through Details appending to object array
-                    foreach($DeviceEntry in $IdentityPoolUsageDetailData.'value')
-                    {
-                        $DeviceDetails =@{
-                            IdentityType = $IdentitySetName
-                            ChassisName = $DeviceEntry.DeviceInfo.ChassisName
-                            ServerName = $DeviceEntry.DeviceInfo.ServerName
-                            ManagementIp = $DeviceEntry.DeviceInfo.ManagementIp
+                    foreach ($DeviceEntry in $IdentityPoolUsageDetailData.'value') {
+                        $DeviceDetails = @{
+                            IdentityType  = $IdentitySetName
+                            ChassisName   = $DeviceEntry.DeviceInfo.ChassisName
+                            ServerName    = $DeviceEntry.DeviceInfo.ServerName
+                            ManagementIp  = $DeviceEntry.DeviceInfo.ManagementIp
                             NicIdentifier = $DeviceEntry.NicIdentifier
-                            MacAddress = $DeviceEntry.MacAddress
+                            MacAddress    = $DeviceEntry.MacAddress
                         }
                         $DeviceData += New-Object PSObject -Property $DeviceDetails 
                     }
 
                     # Check if there are multiple pages in response
-                    if ($IdentityPoolUsageDetailData.'@odata.nextLink'){
+                    if ($IdentityPoolUsageDetailData.'@odata.nextLink') {
                         $NextLinkUrl = $BaseUri + $IdentityPoolUsageDetailData.'@odata.nextLink'
                     }
                     # Loop through pages until end
                     while ($NextLinkUrl) {
-                        $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                        $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                         if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -eq 200) {
                             $IdentityPoolUsageDetailNextLinkData = $IdentityPoolUsageDetailNextLinkResp.Content | ConvertFrom-Json
                             # Loop through Details appending to object array
-                            foreach($DeviceEntry in $IdentityPoolUsageDetailNextLinkData.'value')
-                            {
-                                $DeviceDetails =@{
-                                    IdentityType = $IdentitySetName
-                                    ChassisName = $DeviceEntry.DeviceInfo.ChassisName
-                                    ServerName = $DeviceEntry.DeviceInfo.ServerName
-                                    ManagementIp = $DeviceEntry.DeviceInfo.ManagementIp
+                            foreach ($DeviceEntry in $IdentityPoolUsageDetailNextLinkData.'value') {
+                                $DeviceDetails = @{
+                                    IdentityType  = $IdentitySetName
+                                    ChassisName   = $DeviceEntry.DeviceInfo.ChassisName
+                                    ServerName    = $DeviceEntry.DeviceInfo.ServerName
+                                    ManagementIp  = $DeviceEntry.DeviceInfo.ManagementIp
                                     NicIdentifier = $DeviceEntry.NicIdentifier
-                                    MacAddress = $DeviceEntry.MacAddress
+                                    MacAddress    = $DeviceEntry.MacAddress
                                 }
                                 $DeviceData += New-Object PSObject -Property $DeviceDetails 
                             }
                             # Set for nextLink for next iteration
-                            if ($IdentityPoolUsageDetailNextLinkData.'@odata.nextLink'){
+                            if ($IdentityPoolUsageDetailNextLinkData.'@odata.nextLink') {
                                 $NextLinkUrl = $BaseUri + $IdentityPoolUsageDetailNextLinkData.'@odata.nextLink'
-                            } else { 
+                            }
+                            else { 
                                 $NextLinkUrl = $null
                             }
-                        } else {
+                        }
+                        else {
                             $NextLinkUrl = $null
                             Write-Error "Unable to retrieve items from nextLink... Exiting"
                         }
@@ -219,11 +219,13 @@ Try {
                 if ($OutFile -eq "") {
                     $DeviceData | Export-Csv -Path "Get-IdentityPoolUsage.csv" -NoTypeInformation
                     Write-Host "Exported data to $(Get-Location)\Get-IdentityPoolUsage.csv"
-                } else {
+                }
+                else {
                     $DeviceData | Export-Csv -Path $OutFile -NoTypeInformation
                     Write-Host "Exported data to $($OutFile)"
                 }
-            } else {
+            }
+            else {
                 Write-Host "No data to display"
             }
         }
@@ -233,11 +235,11 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception: $($_)"
 }
-Finally {
+finally {
     if ($AuthToken) {
-      Remove-Session $IpAddress $Headers $AuthToken["id"]
+        Remove-Session $IpAddress $Headers $AuthToken["id"]
     }
 }

--- a/Core/PowerShell/Get-InventoryByType.ps1
+++ b/Core/PowerShell/Get-InventoryByType.ps1
@@ -31,23 +31,23 @@
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
-    [System.Net.IPAddress] $IpAddress,
+  [Parameter(Mandatory)]
+  [System.Net.IPAddress] $IpAddress,
 
-    [Parameter(Mandatory)]
-    [pscredential] $Credentials, 
-    [Parameter(Mandatory=$false)]
-    [ValidateSet("cpus","memory", "controllers", "disks","os")]
-    [String] $InventoryType,
+  [Parameter(Mandatory)]
+  [pscredential] $Credentials, 
+  [Parameter(Mandatory = $false)]
+  [ValidateSet("cpus", "memory", "controllers", "disks", "os")]
+  [String] $InventoryType,
 
-    [Parameter(Mandatory)]
-    [System.UInt32]$DeviceId
+  [Parameter(Mandatory)]
+  [System.UInt32]$DeviceId
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+  ## Trust all certs - for sample usage only
+  Try {
+    add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -58,51 +58,52 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
     }
 }
 "@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    Catch {
-        Write-Error "Unable to add type for cert policy"
-    }
+    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  }
+  catch {
+    Write-Error "Unable to add type for cert policy"
+  }
 }
 
 Try {
-    Set-CertPolicy
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
-    $Headers     = @{}
-    $InventoryTypes = @{"cpus"="serverProcessors";"os"="serverOperatingSystems";"disks"="serverArrayDisks";"controllers"="serverRaidControllers";"memory" ="serverMemoryDevices"}
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
-    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
-        ## Successfully created a session - extract the auth token from the response
-        ## header and update our headers for subsequent requests
-        $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-                if($InventoryType){
-                  $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails('$($InventoryTypes[$InventoryType])')"
-                }else{
-				$InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails"
-				}
-                $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-                if ($InventoryResp.StatusCode -eq 200) {
-                    $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
-					$inventoryDetail =  $InventoryInfo | ConvertTo-Json -Depth 6
-					write-Host $inventoryDetail
-                }
-				elseif($InventoryResp.StatusCode -eq 400){
-					Write-Warning "Inventory type not applicable for device id  $($DeviceId) "
-				}
-                else {
-                    Write-Warning "Unable to retrieve inventory for device $($DeviceId) due to status code ($($InventoryResp.StatusCode))"
-                }
-            
+  Set-CertPolicy
+  $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+  $Type = "application/json"
+  $UserName = $Credentials.username
+  $Password = $Credentials.GetNetworkCredential().password
+  $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
+  $Headers = @{}
+  $InventoryTypes = @{"cpus" = "serverProcessors"; "os" = "serverOperatingSystems"; "disks" = "serverArrayDisks"; "controllers" = "serverRaidControllers"; "memory" = "serverMemoryDevices" }
+  $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+  if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
+    ## Successfully created a session - extract the auth token from the response
+    ## header and update our headers for subsequent requests
+    $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
+    if ($InventoryType) {
+      $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails('$($InventoryTypes[$InventoryType])')"
     }
     else {
-        Write-Error "Unable to create a session with appliance $($IpAddress)"
+      $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails"
+				}
+    $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -Headers $Headers -Method Get -ContentType $Type
+    if ($InventoryResp.StatusCode -eq 200) {
+      $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
+      $inventoryDetail = $InventoryInfo | ConvertTo-Json -Depth 6
+      write-Host $inventoryDetail
     }
+				elseif ($InventoryResp.StatusCode -eq 400) {
+      Write-Warning "Inventory type not applicable for device id  $($DeviceId) "
+				}
+    else {
+      Write-Warning "Unable to retrieve inventory for device $($DeviceId) due to status code ($($InventoryResp.StatusCode))"
+    }
+            
+  }
+  else {
+    Write-Error "Unable to create a session with appliance $($IpAddress)"
+  }
 }
-Catch {
-    Write-Error "Exception occured - $($_.Exception.Message)"
+catch {
+  Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/Invoke-ReportExecution.ps1
+++ b/Core/PowerShell/Invoke-ReportExecution.ps1
@@ -55,21 +55,21 @@ param(
     [Parameter(Mandatory)]
     [uint64] $ReportId,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [uint64] $GroupId = 0,
     
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [ValidateSet("csv", "table")]
-    [string]$OutputFormat="csv",
+    [string]$OutputFormat = "csv",
     
-    [Parameter(Mandatory=$false)]
-    [string]$OutputFilePath=""    
+    [Parameter(Mandatory = $false)]
+    [string]$OutputFilePath = ""    
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+    ## Trust all certs - for sample usage only
+    Try {
+        add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -83,13 +83,12 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 }
 
-function Get-uniquefilename
-{
+function Get-uniquefilename {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
@@ -99,19 +98,16 @@ function Get-uniquefilename
         [String] $formatextension
     )
 
-    if(Test-Path -LiteralPath $filepath -PathType Container)
-    {
+    if (Test-Path -LiteralPath $filepath -PathType Container) {
         Write-Error "Unable to get the file name, please provide the filename"
     }
-    else
-    {
+    else {
         $folder = Split-Path -Path ([io.path]::GetFullPath($filepath)) -Parent
         $formatfilename = $filepath.BaseName
         $i = 1
-        while(Test-Path $filepath)
-        {
-            $filename = $formatfilename+"($i)"
-            $newfilename = $filename+"."+$formatextension
+        while (Test-Path $filepath) {
+            $filename = $formatfilename + "($i)"
+            $newfilename = $filename + "." + $formatextension
             $filepath = Join-Path $folder $newfilename
             $i++
         }
@@ -119,40 +115,42 @@ function Get-uniquefilename
     return $filepath
 }
 
-function Format-OutputInfo($IpAddress,$Headers,$Type,$ReportId) {
+function Format-OutputInfo($IpAddress, $Headers, $Type, $ReportId) {
     $BaseUri = "https://$($IpAddress)"
     $ReportDeets = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))"
     $NextLinkUrl = $null
     $OutputArray = @()
     $ColumnNames = @()
     [psobject[]]$objlist = @()
-    $DeetsResp = Invoke-WebRequest -Uri $ReportDeets -UseBasicParsing -Headers $Headers -Method Get -ContentType $Type
-    if ($DeetsResp.StatusCode -eq 200){
+    $DeetsResp = Invoke-WebRequest -Uri $ReportDeets -Headers $Headers -Method Get -ContentType $Type
+    if ($DeetsResp.StatusCode -eq 200) {
         $DeetsInfo = $DeetsResp.Content | ConvertFrom-Json
         $ColumnNames = $DeetsInfo.ColumnNames.Name
         Write-Verbose "Extracting results for report ($($ReportId))"
         $ResultUrl = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))/ReportResults/ResultRows"
         
-        $RepResult = Invoke-WebRequest -Uri $ResultUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+        $RepResult = Invoke-WebRequest -Uri $ResultUrl -Method Get -Headers $Headers -ContentType $Type
         if ($RepResult.StatusCode -eq 200) {
             $RepInfo = $RepResult.Content | ConvertFrom-Json
             $totalRepResults = [int]($RepInfo.'@odata.count')
             if ($totalRepResults -gt 0) {
                 $ReportResultList = $RepInfo.Value
-                if ($RepInfo.'@odata.nextLink'){
+                if ($RepInfo.'@odata.nextLink') {
                     $NextLinkUrl = $BaseUri + $RepInfo.'@odata.nextLink'
                 }
-                while ($NextLinkUrl){
-                    $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                while ($NextLinkUrl) {
+                    $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($NextLinkResponse.StatusCode -eq 200) {
                         $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                         $ReportResultList += $NextLinkData.'value'
-                        if ($NextLinkData.'@odata.nextLink'){
+                        if ($NextLinkData.'@odata.nextLink') {
                             $NextLinkUrl = $BaseUri + $NextLinkData.'@odata.nextLink'
-                        }else{
+                        }
+                        else {
                             $NextLinkUrl = $null
                         }
-                    }else {
+                    }
+                    else {
                         Write-Error "Unable to get full set of report results"
                         $NextLinkUrl = $null
                     }
@@ -161,23 +159,20 @@ function Format-OutputInfo($IpAddress,$Headers,$Type,$ReportId) {
                     $resultVals = $value.Values
 
                     $tempHash = @{}
-                    for ($i =0; $i -lt $ColumnNames.Count; $i++) {
+                    for ($i = 0; $i -lt $ColumnNames.Count; $i++) {
                         $tempHash[$ColumnNames[$i]] = $resultVals[$i]
                     }
                     $outputArray += , $tempHash
-                    if($outputformat -eq "csv")
-                    {
+                    if ($outputformat -eq "csv") {
                         $objlist += New-Object -TypeName psobject -Property $tempHash
                     }
                 }
-                if($outputformat -eq "csv")
-                {
+                if ($outputformat -eq "csv") {
                     $filepath = Get-uniquefilename -filepath $outputfilepath -formatextension "csv"
                     $objlist | Export-Csv -Path $filepath
                 }
-                else
-                {
-                    $outputArray.Foreach({[PSCustomObject]$_}) | Format-Table -AutoSize
+                else {
+                    $outputArray.Foreach( { [PSCustomObject]$_ }) | Format-Table -AutoSize
                 }
             }
             else {
@@ -194,22 +189,21 @@ function Format-OutputInfo($IpAddress,$Headers,$Type,$ReportId) {
 }
 
 Try {
-    if(($outputformat -like "csv") -and ($outputfilepath -eq ""))
-    {
+    if (($outputformat -like "csv") -and ($outputfilepath -eq "")) {
         Write-Error "CSV Filepath is not provided." -ErrorAction Stop
     }
 
     Set-CertPolicy
-    $SessionUrl    = "https://$($IpAddress)/api/SessionService/Sessions"
-    $ExecRepUrl    = "https://$($IpAddress)/api/ReportService/Actions/ReportService.RunReport"
-    $Type          = "application/json"
-    $UserName      = $Credentials.username
-    $Password      = $Credentials.GetNetworkCredential().password
-    $UserDetails   = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
-    $RepPayload    = @{"ReportDefId"=$ReportId; "FilterGroupId"=$GroupId} | ConvertTo-Json
-    $Headers       = @{}
-    $JobDoneStatus = @("completed","failed","warning","aborted","canceled")
-    $RetryCount    = 90 
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $ExecRepUrl = "https://$($IpAddress)/api/ReportService/Actions/ReportService.RunReport"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
+    $RepPayload = @{"ReportDefId" = $ReportId; "FilterGroupId" = $GroupId } | ConvertTo-Json
+    $Headers = @{}
+    $JobDoneStatus = @("completed", "failed", "warning", "aborted", "canceled")
+    $RetryCount = 90 
 
     
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
@@ -217,7 +211,7 @@ Try {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $ReportResp = Invoke-WebRequest -Uri $ExecRepUrl -UseBasicParsing -Method Post -Headers $Headers -ContentType $Type -Body $RepPayload
+        $ReportResp = Invoke-WebRequest -Uri $ExecRepUrl -Method Post -Headers $Headers -ContentType $Type -Body $RepPayload
         if ($ReportResp.StatusCode -eq 200) {
             $JobId = $ReportResp.Content
             $JobUrl = "https://$($IpAddress)/api/JobService/Jobs($($JobId))"
@@ -227,7 +221,7 @@ Try {
                 $Counter++
                 Write-Host "Polling report status ... "
                 Start-Sleep -Seconds 10                
-                $JobResp = Invoke-WebRequest -Uri $JobUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                $JobResp = Invoke-WebRequest -Uri $JobUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($JobResp.StatusCode -eq 200) {
                     $JobInfo = $JobResp.Content | ConvertFrom-Json
                     $CurrJobStatus = [string]($JobInfo.LastRunStatus.Name).ToLower()
@@ -244,7 +238,7 @@ Try {
             else {
                 Write-Warning "Job $($JobId) failed ... Unable to run report"
             }
-                }
+        }
         else {
             Write-Warning "Unable to retrieve reports from $($IpAddress)"
         }
@@ -253,6 +247,6 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/Invoke-RetireLead.ps1
+++ b/Core/PowerShell/Invoke-RetireLead.ps1
@@ -32,7 +32,7 @@ limitations under the License.
 
  .EXAMPLE
    $cred = Get-Credential
-   .\Create-McmGroup.ps1 -IpAddress "10.xx.xx.xx" -Credentials $cred
+   .\Invoke-RetireLead.ps1 -IpAddress "10.xx.xx.xx" -Credentials $cred
 
    In this instance you will be prompted for credentials to use to
    connect to the appliance
@@ -63,13 +63,10 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 }
-
-
-
 
 
 function Retire-Lead($IpAddress, $Headers) {
@@ -78,7 +75,7 @@ function Retire-Lead($IpAddress, $Headers) {
     $BackupLead = Get-BackupLead $IpAddress $Headers
     $JobId = 0
     $AssignBackupLeadRequired = 0
-    if ($null -eq $BackupLead){
+    if ($null -eq $BackupLead) {
         $AssignBackupLeadRequired = 1
         Write-Host "No backup lead found. Assigning backup lead"
         $JobId = Assign-BackupLead $IpAddress $Headers
@@ -91,14 +88,14 @@ function Retire-Lead($IpAddress, $Headers) {
         }
     }
 
-    if($AssignBackupLeadRequired){
+    if ($AssignBackupLeadRequired) {
         Write-Host "Waiting for sync operation to complete for assign backup lead"
         Start-Sleep -Seconds 900
     }
     $BackupLead = Get-BackupLead $IpAddress $Headers
     Write-Host "Checking Backup lead health"
     $BackupLeadHealth = $BackupLead.'BackupLeadHealth'
-    if($BackupLeadHealth -ne 1000){
+    if ($BackupLeadHealth -ne 1000) {
         Write-Host "Backup lead health is CRITICAL or WARNING."
         Write-Host "Please ensure backup lead is healty before retiring the lead"
         return $null
@@ -110,7 +107,7 @@ function Retire-Lead($IpAddress, $Headers) {
     }' | ConvertFrom-Json
 
     $Body = $Payload | ConvertTo-Json -Depth 6
-    $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
     if ($Response.StatusCode -eq 200) {
         $RetireLeadResp = $Response | ConvertFrom-Json
         $JobId = $RetireLeadResp.'JobId'
@@ -139,7 +136,7 @@ function Assign-BackupLead($IpAddress, $Headers) {
         $TargetTempHash."Id" = $MemberId
         $TargetArray += $TargetTempHash
         $Body = ConvertTo-Json $TargetArray
-        $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $BackupLeadData = $Response | ConvertFrom-Json
             $JobId = $BackupLeadData.'JobId'
@@ -159,7 +156,7 @@ function Get-Domains($IpAddress, $Headers) {
     $Lead = $null
     $BackupLead = $null
     $URL = "https://$($IpAddress)/api/ManagementDomainService/Domains"
-    $Response = Invoke-WebRequest -Uri $URL -UseBasicParsing -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -168,7 +165,7 @@ function Get-Domains($IpAddress, $Headers) {
                 $Role = $Member.'DomainRoleTypeValue'
                 $BackupLeadFlag = $Member.'BackupLead'
                 if ($Role -eq "LEAD") {
-                    if ($null -eq $Lead){
+                    if ($null -eq $Lead) {
                         $Lead = $Member
                     }
                 }
@@ -228,7 +225,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -UseBasicParsing -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -241,12 +238,12 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -UseBasicParsing -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -UseBasicParsing -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -261,11 +258,9 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             }
             else { continue }
         }
-        else {Write-Warning "Unable to get status for $($JobId) .. Iteration $($Ctr)"}
+        else { Write-Warning "Unable to get status for $($JobId) .. Iteration $($Ctr)" }
     } until ($Ctr -ge $MAX_RETRIES)
 }
-
-
 
 
 ## Script that does the work
@@ -275,7 +270,7 @@ Try {
     $Type = "application/json"
     $UserName = $Credentials.username
     $Password = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API"} | ConvertTo-Json
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
 
 
@@ -298,6 +293,6 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception occured - $($_.Exception.Message)"
 }

--- a/Core/PowerShell/New-Network.ps1
+++ b/Core/PowerShell/New-Network.ps1
@@ -77,23 +77,23 @@ param(
     [Parameter(Mandatory)]
     [pscredential] $Credentials,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch] $ExportExample,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch] $ListNetworks,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [switch] $ListNetworkTypes,
 
-    [Parameter(Mandatory=$false)]
+    [Parameter(Mandatory = $false)]
     [string] $InFile
 )
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-Try {
-add-type @"
+    ## Trust all certs - for sample usage only
+    Try {
+        add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -107,7 +107,7 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 
@@ -116,34 +116,34 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
 $SessionAuthToken = @{}
 
 function Get-Session($IpAddress, $Credentials) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         $SessionAuthToken = @{
-        "token"= $SessResponse.Headers["X-Auth-Token"];
-        "id"= $SessResponseData.Id
+            "token" = $SessResponse.Headers["X-Auth-Token"];
+            "id"    = $SessResponseData.Id
         }
     }
     return $SessionAuthToken
 }
 
 function Remove-Session($IpAddress, $Headers, $Id) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
-    $Type        = "application/json"
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
+    $Type = "application/json"
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
 }
 
 function Get-Networks($BaseUri, $Headers) {
     # Display Networks
-    $Type        = "application/json"
+    $Type = "application/json"
     $NetworkUrl = $BaseUri + "/api/NetworkConfigurationService/Networks"
-    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
     if ($NetworkResp.StatusCode -eq 200) {
         $NetworkRespData = $NetworkResp.Content | ConvertFrom-Json
         $NetworkRespData = $NetworkRespData.'value'
@@ -154,9 +154,9 @@ function Get-Networks($BaseUri, $Headers) {
 
 function Get-NetworkTypes($BaseUri, $Headers) {
     # Display Network Types
-    $Type        = "application/json"
+    $Type = "application/json"
     $NetworkTypeUrl = $BaseUri + "/api/NetworkConfigurationService/NetworkTypes"
-    $NetworkTypeResp = Invoke-WebRequest -Uri $NetworkTypeUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+    $NetworkTypeResp = Invoke-WebRequest -Uri $NetworkTypeUrl -Method Get -Headers $Headers -ContentType $Type
     if ($NetworkTypeResp.StatusCode -eq 200) {
         $NetworkTypeRespData = $NetworkTypeResp.Content | ConvertFrom-Json
         $NetworkTypeRespData = $NetworkTypeRespData.'value'
@@ -167,11 +167,11 @@ function Get-NetworkTypes($BaseUri, $Headers) {
 
 function Export-ExampleCSV() {
     $Example = [pscustomobject]@{
-        "Name"= "VLAN 800";
-        "Description"= "Description for VLAN 800";
-        "VlanMinimum"= 800;
-        "VlanMaximum"= 800;
-        "NetworkType"= 1;
+        "Name"        = "VLAN 800";
+        "Description" = "Description for VLAN 800";
+        "VlanMinimum" = 800;
+        "VlanMaximum" = 800;
+        "NetworkType" = 1;
     }
     $Example | Export-Csv -Path .\New-NetworkExample.csv -NoTypeInformation
     Write-Host "Exported example data to $(Get-Location)\New-NetworkExample.csv"
@@ -180,8 +180,8 @@ function Export-ExampleCSV() {
 Try {
     Set-CertPolicy
     $BaseUri = "https://$($IpAddress)"
-    $Type        = "application/json"
-    $Headers     = @{}
+    $Type = "application/json"
+    $Headers = @{}
 
     # Export example CSV file
     if ($ExportExample) {
@@ -209,25 +209,26 @@ Try {
         if ($InFile -ne "" -and (Test-Path $InFile)) {
             Import-CSV $InFile | Foreach-Object {
                 $Payload = @{
-                    "Name"= $_.Name;
-                    "Description"= $_.Description;
-                    "VlanMaximum"= $_.VlanMinimum -as [int];
-                    "VlanMinimum"= $_.VlanMaximum -as [int];
-                    "Type"= $_.NetworkType -as [int];
+                    "Name"        = $_.Name;
+                    "Description" = $_.Description;
+                    "VlanMaximum" = $_.VlanMinimum -as [int];
+                    "VlanMinimum" = $_.VlanMaximum -as [int];
+                    "Type"        = $_.NetworkType -as [int];
                 }
                 $PayloadJson = $Payload | ConvertTo-Json
                 Write-Host "Creating Network from data: $($PayloadJson)"
                 # Create Network
                 Try {
                     $CreateNetworkUrl = $BaseUri + "/api/NetworkConfigurationService/Networks"
-                    $CreateResp = Invoke-WebRequest -Uri $CreateNetworkUrl -UseBasicParsing -Me Post -H $Headers -Con $Type -Body $PayloadJson
+                    $CreateResp = Invoke-WebRequest -Uri $CreateNetworkUrl -Me Post -H $Headers -Con $Type -Body $PayloadJson
                     if ($CreateResp.StatusCode -eq 201) {
                         Write-Host "New Network created $($_)"
                     }
                     else {
                         Write-Host $CreateResp.Content
                     }
-                } Catch {
+                }
+                catch {
                     Write-Host "Exception: $($_)"
                 }
             }
@@ -237,11 +238,11 @@ Try {
         Write-Error "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception: $($_)"
 }
-Finally {
+finally {
     if ($AuthToken) {
-      Remove-Session $IpAddress $Headers $AuthToken["id"]
+        Remove-Session $IpAddress $Headers $AuthToken["id"]
     }
 }

--- a/Core/PowerShell/Set-ScaleVlanProfile.ps1
+++ b/Core/PowerShell/Set-ScaleVlanProfile.ps1
@@ -49,121 +49,120 @@ param(
     [pscredential] $Credentials,
 
     [Parameter(Mandatory)]
-    [ValidateSet("Enabled","Disabled")]
+    [ValidateSet("Enabled", "Disabled")]
     [String] $ProfileState
 )
 
 # RKR - changing input param to Idictionary to help use an ordered dictionary
 # and prevent scrambling keys in random order ...
-function fShowMenu([System.String]$sMenuTitle,[System.Collections.IDictionary]$hMenuEntries)
-{
+function fShowMenu([System.String]$sMenuTitle, [System.Collections.IDictionary]$hMenuEntries) {
     
-	[System.Int16]$iSavedBackgroundColor=[System.Console]::BackgroundColor
-	[System.Int16]$iSavedForegroundColor=[System.Console]::ForegroundColor
-	# Menu Colors
-	# inverse fore- and backgroundcolor 
-	[System.Int16]$iMenuForeGroundColor=$iSavedForegroundColor
-	[System.Int16]$iMenuBackGroundColor=$iSavedBackgroundColor
-	[System.Int16]$iMenuBackGroundColorSelectedLine=$iMenuForeGroundColor
-	[System.Int16]$iMenuForeGroundColorSelectedLine=$iMenuBackGroundColor
-	[System.Int16]$iMenuStartLineAbsolute=0
-	[System.Int16]$iMenuLoopCount=0
-	[System.Int16]$iMenuSelectLine=1
-	[System.Int16]$iMenuEntries=$hMenuEntries.Count
-	[Hashtable]$hMenu=@{};
-	[Hashtable]$hMenuHotKeyList=@{};
-	[Hashtable]$hMenuHotKeyListReverse=@{};
-	[System.Int16]$iMenuHotKeyChar=0
-	[System.String]$sValidChars=""
-	[System.Console]::WriteLine(" "+$sMenuTitle)
-	$iMenuLoopCount=1
-	$iMenuHotKeyChar=49
-	foreach ($sKey in $hMenuEntries.Keys){
+    [System.Int16]$iSavedBackgroundColor = [System.Console]::BackgroundColor
+    [System.Int16]$iSavedForegroundColor = [System.Console]::ForegroundColor
+    # Menu Colors
+    # inverse fore- and backgroundcolor 
+    [System.Int16]$iMenuForeGroundColor = $iSavedForegroundColor
+    [System.Int16]$iMenuBackGroundColor = $iSavedBackgroundColor
+    [System.Int16]$iMenuBackGroundColorSelectedLine = $iMenuForeGroundColor
+    [System.Int16]$iMenuForeGroundColorSelectedLine = $iMenuBackGroundColor
+    [System.Int16]$iMenuStartLineAbsolute = 0
+    [System.Int16]$iMenuLoopCount = 0
+    [System.Int16]$iMenuSelectLine = 1
+    [System.Int16]$iMenuEntries = $hMenuEntries.Count
+    [Hashtable]$hMenu = @{};
+    [Hashtable]$hMenuHotKeyList = @{};
+    [Hashtable]$hMenuHotKeyListReverse = @{};
+    [System.Int16]$iMenuHotKeyChar = 0
+    [System.String]$sValidChars = ""
+    [System.Console]::WriteLine(" " + $sMenuTitle)
+    $iMenuLoopCount = 1
+    $iMenuHotKeyChar = 49
+    foreach ($sKey in $hMenuEntries.Keys) {
         ## RKR - fix showing values instead of keys....
-		$hMenu.Add([System.Int16]$iMenuLoopCount,[System.String]$hMenuEntries[$sKey])
-		$hMenuHotKeyList.Add([System.Int16]$iMenuLoopCount,[System.Convert]::ToChar($iMenuHotKeyChar))
-		$hMenuHotKeyListReverse.Add([System.Convert]::ToChar($iMenuHotKeyChar),[System.Int16]$iMenuLoopCount)
-		$sValidChars+=[System.Convert]::ToChar($iMenuHotKeyChar)
-		$iMenuLoopCount++
-		$iMenuHotKeyChar++
-		if($iMenuHotKeyChar -eq 58){$iMenuHotKeyChar=97}
-		elseif($iMenuHotKeyChar -eq 123){$iMenuHotKeyChar=65}
-		elseif($iMenuHotKeyChar -eq 91){
-			Write-Error " Menu too big!"
-			exit(99)
-		}
-	}
-	# Remember Menu start
-	[System.Int16]$iBufferFullOffset=0
-	$iMenuStartLineAbsolute=[System.Console]::CursorTop
-	do{
-		####### Draw Menu  #######
-		[System.Console]::CursorTop=($iMenuStartLineAbsolute-$iBufferFullOffset)
-		for ($iMenuLoopCount=1;$iMenuLoopCount -le $iMenuEntries;$iMenuLoopCount++){
-			[System.Console]::Write("`r")
-			[System.String]$sPreMenuline=""
-			$sPreMenuline="  "+$hMenuHotKeyList[[System.Int16]$iMenuLoopCount]
-			$sPreMenuline+=": "
-			if ($iMenuLoopCount -eq $iMenuSelectLine){
-				[System.Console]::BackgroundColor=$iMenuBackGroundColorSelectedLine
-				[System.Console]::ForegroundColor=$iMenuForeGroundColorSelectedLine
-			}
-			if ($hMenuEntries.Item([System.String]$hMenu.Item($iMenuLoopCount)).Length -gt 0){
-				[System.Console]::Write($sPreMenuline+$hMenuEntries.Item([System.String]$hMenu.Item($iMenuLoopCount)))
-			}
-			else{
-				[System.Console]::Write($sPreMenuline+$hMenu.Item($iMenuLoopCount))
-			}
-			[System.Console]::BackgroundColor=$iMenuBackGroundColor
-			[System.Console]::ForegroundColor=$iMenuForeGroundColor
-			[System.Console]::WriteLine("")
-		}
-		[System.Console]::BackgroundColor=$iMenuBackGroundColor
-		[System.Console]::ForegroundColor=$iMenuForeGroundColor
-		[System.Console]::Write("  Your choice: " )
-		if (($iMenuStartLineAbsolute+$iMenuLoopCount) -gt [System.Console]::BufferHeight){
-			$iBufferFullOffset=($iMenuStartLineAbsolute+$iMenuLoopCount)-[System.Console]::BufferHeight
-		}
-		####### End Menu #######
-		####### Read Kex from Console 
-		$oInputChar=[System.Console]::ReadKey($true)
-		# Down Arrow?
-		if ([System.Int16]$oInputChar.Key -eq [System.ConsoleKey]::DownArrow){
-			if ($iMenuSelectLine -lt $iMenuEntries){
-				$iMenuSelectLine++
-			}
-		}
-		# Up Arrow
-		elseif([System.Int16]$oInputChar.Key -eq [System.ConsoleKey]::UpArrow){
-			if ($iMenuSelectLine -gt 1){
-				$iMenuSelectLine--
-			}
-		}
-		elseif([System.Char]::IsLetterOrDigit($oInputChar.KeyChar)){
-			[System.Console]::Write($oInputChar.KeyChar.ToString())	
-		}
-		[System.Console]::BackgroundColor=$iMenuBackGroundColor
-		[System.Console]::ForegroundColor=$iMenuForeGroundColor
-	} while(([System.Int16]$oInputChar.Key -ne [System.ConsoleKey]::Enter) -and ($sValidChars.IndexOf($oInputChar.KeyChar) -eq -1))
+        $hMenu.Add([System.Int16]$iMenuLoopCount, [System.String]$hMenuEntries[$sKey])
+        $hMenuHotKeyList.Add([System.Int16]$iMenuLoopCount, [System.Convert]::ToChar($iMenuHotKeyChar))
+        $hMenuHotKeyListReverse.Add([System.Convert]::ToChar($iMenuHotKeyChar), [System.Int16]$iMenuLoopCount)
+        $sValidChars += [System.Convert]::ToChar($iMenuHotKeyChar)
+        $iMenuLoopCount++
+        $iMenuHotKeyChar++
+        if ($iMenuHotKeyChar -eq 58) { $iMenuHotKeyChar = 97 }
+        elseif ($iMenuHotKeyChar -eq 123) { $iMenuHotKeyChar = 65 }
+        elseif ($iMenuHotKeyChar -eq 91) {
+            Write-Error " Menu too big!"
+            exit(99)
+        }
+    }
+    # Remember Menu start
+    [System.Int16]$iBufferFullOffset = 0
+    $iMenuStartLineAbsolute = [System.Console]::CursorTop
+    do {
+        ####### Draw Menu  #######
+        [System.Console]::CursorTop = ($iMenuStartLineAbsolute - $iBufferFullOffset)
+        for ($iMenuLoopCount = 1; $iMenuLoopCount -le $iMenuEntries; $iMenuLoopCount++) {
+            [System.Console]::Write("`r")
+            [System.String]$sPreMenuline = ""
+            $sPreMenuline = "  " + $hMenuHotKeyList[[System.Int16]$iMenuLoopCount]
+            $sPreMenuline += ": "
+            if ($iMenuLoopCount -eq $iMenuSelectLine) {
+                [System.Console]::BackgroundColor = $iMenuBackGroundColorSelectedLine
+                [System.Console]::ForegroundColor = $iMenuForeGroundColorSelectedLine
+            }
+            if ($hMenuEntries.Item([System.String]$hMenu.Item($iMenuLoopCount)).Length -gt 0) {
+                [System.Console]::Write($sPreMenuline + $hMenuEntries.Item([System.String]$hMenu.Item($iMenuLoopCount)))
+            }
+            else {
+                [System.Console]::Write($sPreMenuline + $hMenu.Item($iMenuLoopCount))
+            }
+            [System.Console]::BackgroundColor = $iMenuBackGroundColor
+            [System.Console]::ForegroundColor = $iMenuForeGroundColor
+            [System.Console]::WriteLine("")
+        }
+        [System.Console]::BackgroundColor = $iMenuBackGroundColor
+        [System.Console]::ForegroundColor = $iMenuForeGroundColor
+        [System.Console]::Write("  Your choice: " )
+        if (($iMenuStartLineAbsolute + $iMenuLoopCount) -gt [System.Console]::BufferHeight) {
+            $iBufferFullOffset = ($iMenuStartLineAbsolute + $iMenuLoopCount) - [System.Console]::BufferHeight
+        }
+        ####### End Menu #######
+        ####### Read Kex from Console 
+        $oInputChar = [System.Console]::ReadKey($true)
+        # Down Arrow?
+        if ([System.Int16]$oInputChar.Key -eq [System.ConsoleKey]::DownArrow) {
+            if ($iMenuSelectLine -lt $iMenuEntries) {
+                $iMenuSelectLine++
+            }
+        }
+        # Up Arrow
+        elseif ([System.Int16]$oInputChar.Key -eq [System.ConsoleKey]::UpArrow) {
+            if ($iMenuSelectLine -gt 1) {
+                $iMenuSelectLine--
+            }
+        }
+        elseif ([System.Char]::IsLetterOrDigit($oInputChar.KeyChar)) {
+            [System.Console]::Write($oInputChar.KeyChar.ToString())	
+        }
+        [System.Console]::BackgroundColor = $iMenuBackGroundColor
+        [System.Console]::ForegroundColor = $iMenuForeGroundColor
+    } while (([System.Int16]$oInputChar.Key -ne [System.ConsoleKey]::Enter) -and ($sValidChars.IndexOf($oInputChar.KeyChar) -eq -1))
 	
-	# reset colors
-	[System.Console]::ForegroundColor=$iSavedForegroundColor
-	[System.Console]::BackgroundColor=$iSavedBackgroundColor
-	if($oInputChar.Key -eq [System.ConsoleKey]::Enter){
-		[System.Console]::Writeline($hMenuHotKeyList[$iMenuSelectLine])
-		return([System.String]$hMenu.Item($iMenuSelectLine))
-	}
-	else{
-		[System.Console]::Writeline("")
-		return($hMenu[$hMenuHotKeyListReverse[$oInputChar.KeyChar]])
-	}
+    # reset colors
+    [System.Console]::ForegroundColor = $iSavedForegroundColor
+    [System.Console]::BackgroundColor = $iSavedBackgroundColor
+    if ($oInputChar.Key -eq [System.ConsoleKey]::Enter) {
+        [System.Console]::Writeline($hMenuHotKeyList[$iMenuSelectLine])
+        return([System.String]$hMenu.Item($iMenuSelectLine))
+    }
+    else {
+        [System.Console]::Writeline("")
+        return($hMenu[$hMenuHotKeyListReverse[$oInputChar.KeyChar]])
+    }
 }
 
 function Set-CertPolicy() {
-## Trust all certs - for sample usage only
-## customers are expected to use strict cert validation
-Try {
-add-type @"
+    ## Trust all certs - for sample usage only
+    ## customers are expected to use strict cert validation
+    Try {
+        add-type @"
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -177,45 +176,45 @@ public class TrustAllCertsPolicy : ICertificatePolicy {
         [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
-    Catch {
+    catch {
         Write-Error "Unable to add type for cert policy"
     }
 
 }
 
 function Get-Session($IpAddress, $Credentials) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions"
-    $Type        = "application/json"
-    $UserName    = $Credentials.username
-    $Password    = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName"=$UserName;"Password"=$Password;"SessionType"="API"} | ConvertTo-Json
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
+    $Type = "application/json"
+    $UserName = $Credentials.username
+    $Password = $Credentials.GetNetworkCredential().password
+    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         Write-Host "Successful authentication with $($IpAddress)"
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         $SessionAuthToken = @{
-        "token"= $SessResponse.Headers["X-Auth-Token"];
-        "id"= $SessResponseData.Id
+            "token" = $SessResponse.Headers["X-Auth-Token"];
+            "id"    = $SessResponseData.Id
         }
     }
     return $SessionAuthToken
 }
 
 function Remove-Session($IpAddress, $Headers, $Id) {
-    $SessionUrl  = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
-    $Type        = "application/json"
+    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
+    $Type = "application/json"
     $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
     Write-Host "Deleted authentication token ..."
 }
 
 function Get-Networks($BaseUri, $Headers) {
     # Display Networks
-    $Type        = "application/json"
-    $NetworkUrl  = $BaseUri + "/api/NetworkService/Fabrics"
+    $Type = "application/json"
+    $NetworkUrl = $BaseUri + "/api/NetworkService/Fabrics"
     Write-Host "Enumerating fabrics ..."
-    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
-    $FabricData  = @()
+    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
+    $FabricData = @()
     $FabricLookup = @{}
     $NextLinkUrl = $null
 
@@ -228,7 +227,7 @@ function Get-Networks($BaseUri, $Headers) {
                 $NextLinkUrl = $BaseUri + $NetworkRespData.'@odata.nextLink'
             }
             while ($NextLinkUrl) {
-                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -UseBasicParsing -Method Get -Headers $Headers -ContentType $Type
+                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($NextLinkResponse.StatusCode -eq 200) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $FabricData += $NextLinkData.'value'
@@ -260,18 +259,18 @@ function Get-Networks($BaseUri, $Headers) {
 }
 
 function Set-ScaleVlanProfileProperty($BaseUri, $Headers, $selection, $FabricData) {
-    $Type        = "application/json"
+    $Type = "application/json"
     Write-Host "Enumerating Fabric Design ...."
     $DesignURL = $BaseUri + "/api/NetworkService/Fabrics" + "('" + "$($selection)" + "')/FabricDesign"
-    $DesignResp = Invoke-WebRequest -Uri $DesignURL -UseBasicParsing -Method Get -H $Headers -Con $Type
+    $DesignResp = Invoke-WebRequest -Uri $DesignURL -Method Get -H $Headers -Con $Type
     if ($DesignResp.StatusCode -eq 200) {
         $DesignRespData = $DesignResp.Content | ConvertFrom-Json
-        $foo = @{"Name" = $DesignRespData.Name}
+        $foo = @{"Name" = $DesignRespData.Name }
         $FabricData.FabricDesign = $foo
-        $PayloadInfo = $FabricData | Select-Object Name, Id, Description, ScaleVlanProfile, FabricDesignMapping,OverrideLLDPConfiguration,FabricDesign | ConvertTo-Json -Depth 4 | ForEach-Object {[System.Text.RegularExpressions.Regex]::Unescape($_) }
+        $PayloadInfo = $FabricData | Select-Object Name, Id, Description, ScaleVlanProfile, FabricDesignMapping, OverrideLLDPConfiguration, FabricDesign | ConvertTo-Json -Depth 4 | ForEach-Object { [System.Text.RegularExpressions.Regex]::Unescape($_) }
         Write-Host "Modifying ScaleVLANProfile property ....."
         $ActionURL = $BaseUri + "/api/NetworkService/Fabrics" + "('" + "$($selection)" + "')"    
-        $ReplaceResp = Invoke-WebRequest -Uri $ActionURL -UseBasicParsing -Me Put -H $Headers -Con $Type -Body $PayloadInfo
+        $ReplaceResp = Invoke-WebRequest -Uri $ActionURL -Me Put -H $Headers -Con $Type -Body $PayloadInfo
         if ($ReplaceResp.StatusCode -eq 201 -or $ReplaceResp.StatusCode -eq 200) {
             Write-Host "Successfully modified ScaleVlanProfile property ...."
         }
@@ -289,8 +288,8 @@ Try {
     Set-CertPolicy
     $IpAddress = $OmemIPAddr
     $BaseUri = "https://$($IpAddress)"
-    $Type        = "application/json"
-    $Headers     = @{}
+    $Type = "application/json"
+    $Headers = @{}
 
 
     # Request authentication session token
@@ -299,17 +298,16 @@ Try {
         # Successfully created a session, extract token
         $Headers."X-Auth-Token" = $AuthToken["token"]       
         $FabricDataArr = Get-Networks $BaseUri $Headers
-        if ($FabricDataArr) 
-        {
+        if ($FabricDataArr) {
             $FabricData = $FabricDataArr[0]
             Write-Host "Enumerated IOMs ... Displaying fabric info ...."
-            $FabricData | Select-Object Name, Id, ScaleVlanProfile, Description| Format-Table | Out-String
+            $FabricData | Select-Object Name, Id, ScaleVlanProfile, Description | Format-Table | Out-String
             $FabricChoices = New-Object System.Collections.ObjectModel.Collection[System.Management.Automation.Host.ChoiceDescription]
             $FabricMap = [ordered]@{}
             $ctr = 0
             $caption = "Select fabric on which ScaleVLANProfile property will be set ..."
             foreach ($Fabric in $FabricData) {
-                $nix =  $FabricMap.Insert($ctr,$ctr, $Fabric.Id)
+                $nix = $FabricMap.Insert($ctr, $ctr, $Fabric.Id)
                 $ctr += 1
             }
 
@@ -330,11 +328,11 @@ Try {
         Write-Warning "Unable to create a session with appliance $($IpAddress)"
     }
 }
-Catch {
+catch {
     Write-Error "Exception: $($_)"
 }
-Finally {
+finally {
     if ($AuthToken) {
-      Remove-Session $IpAddress $Headers $AuthToken["id"]
+        Remove-Session $IpAddress $Headers $AuthToken["id"]
     }
 }

--- a/Core/Python/edit_discovery_job.py
+++ b/Core/Python/edit_discovery_job.py
@@ -27,7 +27,7 @@ DESCRIPTION:
    Note that the credentials entered are not stored to disk.
 
 EXAMPLE:
-   python modify_discovery_job.py --ip <ip addr> --user admin
+   python edit_discovery_job.py --ip <ip addr> --user admin
     --password <passwd> --jobNamePattern <Existing Discovery Job name>
     --targetUserName <user name> --targetPassword <password>
     --targetIpAddresses <10.xx.xx.x,10.xx.xx.xx-10.yy.yy.yy,10.xx.xx.xx>

--- a/Core/Python/get_group_details_by_filter.py
+++ b/Core/Python/get_group_details_by_filter.py
@@ -31,7 +31,7 @@ DESCRIPTION:
    Note that the credentials entered are not stored to disk.
 
 EXAMPLE:
-    python get_group_details_filter.py --ip <xx> --user <username> --password <pwd>
+    python get_group_details_by_filter.py --ip <xx> --user <username> --password <pwd>
         --filterby Name --field "All Devices"
 """
 import argparse

--- a/Core/Python/invoke_report_execution.py
+++ b/Core/Python/invoke_report_execution.py
@@ -51,7 +51,7 @@ API WORKFLOW:
     and print out results
 
 EXAMPLE:
-    python .\run_existing_report.py  --ip <ip addr> --user <username>
+    python .\invoke_report_execution.py  --ip <ip addr> --user <username>
         --password <password> --reportid 10051
 """
 import sys

--- a/Core/Python/invoke_retire_lead.py
+++ b/Core/Python/invoke_retire_lead.py
@@ -28,7 +28,7 @@ This script retires the current lead and the backup lead gets promoted as the ne
  1. Credentials entered are not stored to disk.
  
 Example:
-python retire_lead.py --ip <lead ip> --user <username> --password <password>
+python invoke_retire_lead.py --ip <lead ip> --user <username> --password <password>
 
 retires the current lead and promotes the backup lead
 

--- a/Core/Python/new_static_group.py
+++ b/Core/Python/new_static_group.py
@@ -31,7 +31,7 @@ DESCRIPTION:
    Note that the credentials entered are not stored to disk.
 
 EXAMPLE:
-   python create_static_group.py --ip <xx> --user <username> --password <pwd> --groupname "Random Test Group"
+   python new_static_group.py --ip <xx> --user <username> --password <pwd> --groupname "Random Test Group"
 """
 import json
 import sys

--- a/Core/Python/update_installed_firmware.py
+++ b/Core/Python/update_installed_firmware.py
@@ -31,7 +31,7 @@ Description:
  Note that the credentials entered are not stored to disk.
 
 Example:
-python update_firmware_using_dup.py --ip <ip addr> --user admin
+python update_installed_firmware.py --ip <ip addr> --user admin
     --password <passwd> --groupid 25315
     --dupfile iDRAC-with-Lifecycle-Controller_Firmware_387FW_WN64_3.21.21.21_A00.EXE
 


### PR DESCRIPTION
- Changed all instances of Catch to catch
- Changed all instances of Finally to finally
- Ran Microsoft's Powershell formatter on all files
- Overhauled Get-DeviceList.ps1 and Get-GroupList. Added function documentation and updated it to use pscredentials and Invoke-RestMethod. This fixes #61/#63 for this script.
- Reseloved #64. Removed -UseBasicParsing in all files as it is no longer necessary.
- Updated modify_discovery_job to Edit-DiscoveryJob/edit_discovery_job so that there is clear parity between Python and PowerShell and it uses an approved PowerShell verb. Also fixed a typo in Modify-DiscoveryJob.
- Fixed typo in get_group_details_filter.py and updated the name to get_group_details_by_filter for parity with PowerShell
- Updated the name of run_existing_report to invoke_report_execution
- Changed the name create_static_group.py to new_static_group.py for clear parity
- Changed retire_lead to invoke_retire_lead.py and Invoke-RetireLead.ps1 respectively
- Changed name of update_installed_dup.py to update_installed_firmware.py for parity with Powershell

Signed-off-by: Grant Curell <grant_curell@dell.com>