### PR TITLE
add_device_to_static_group.py: Overhaul

### DIFF
--- a/Core/Python/get_alerts.py
+++ b/Core/Python/get_alerts.py
@@ -138,11 +138,6 @@ def get_data(authenticated_headers: dict, url: str, odata_filter: str = None, ma
     else:
         count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-        if count_data.status_code == 400:
-            print("Received an error while retrieving data from %s:" % url)
-            pprint(count_data.json()['error'])
-            return []
-
     if 'value' in count_data:
         data = count_data['value']
     else:

--- a/Core/Python/get_audit_logs.py
+++ b/Core/Python/get_audit_logs.py
@@ -126,11 +126,6 @@ def get_data(authenticated_headers: dict, url: str, odata_filter: str = None, ma
     else:
         count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-        if count_data.status_code == 400:
-            print("Received an error while retrieving data from %s:" % url)
-            pprint(count_data.json()['error'])
-            return []
-
     if 'value' in count_data:
         data = count_data['value']
     else:

--- a/Core/Python/get_firmware_baselines.py
+++ b/Core/Python/get_firmware_baselines.py
@@ -104,11 +104,6 @@ def get_data(authenticated_headers: dict, url: str, odata_filter: str = None) ->
     else:
         count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-        if count_data.status_code == 400:
-            print("Received an error while retrieving data from %s:" % url)
-            pprint(count_data.json()['error'])
-            return []
-
     if 'value' in count_data:
         data = count_data['value']
     else:

--- a/Core/Python/invoke_refresh_inventory.py
+++ b/Core/Python/invoke_refresh_inventory.py
@@ -149,11 +149,6 @@ def get_data(authenticated_headers: dict, url: str, odata_filter: str = None, ma
     else:
         count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-        if count_data.status_code == 400:
-            print("Received an error while retrieving data from %s:" % url)
-            pprint(count_data.json()['error'])
-            return []
-
     if 'value' in count_data:
         data = count_data['value']
     else:

--- a/Core/Python/set_power_state.py
+++ b/Core/Python/set_power_state.py
@@ -117,11 +117,6 @@ def get_data(authenticated_headers: dict, url: str, odata_filter: str = None, ma
     else:
         count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-        if count_data.status_code == 400:
-            print("Received an error while retrieving data from %s:" % url)
-            pprint(count_data.json()['error'])
-            return []
-
     if 'value' in count_data:
         data = count_data['value']
     else:

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,13 +101,16 @@ Deploy scripts include those things for discovery and generating the initial inv
 Add one or more hosts to an existing static group.
 
 #### Description
-This script exercises the OME REST API to add one or more
-hosts to an existing static group. For authentication X-Auth
-is used over Basic Authentication. Note: The credentials entered
-are not stored to disk.
+This script exercises the OME REST API to add one or more hosts to an existing static group. You can provide specific
+ devices or you can provide the job ID for a previous discovery job containing a set of servers. The script will pull
+ from the discovery job and add those servers to a gorup. For authentication X-Auth is used over Basic Authentication.
+Note: The credentials entered are not stored to disk.
 
 #### Python Example
-    `python add_device_to_static_group.py --ip <xx> --user <username> --password <pwd> --groupname "Random Test Group" --devicenames "cmc1,host3,192.168.1.5"`
+    ```
+    python add_device_to_static_group.py --idrac-ips 192.168.1.45,192.168.1.63 --groupname 格蘭特 --password somepass --ip 192.168.1.93 --use-discovery-job-id 14028
+    python add_device_to_static_group.py --service-tags servtag1,servtag2,servtag3 --groupname 格蘭特 --password somepass --ip 192.168.1.93
+    ```
 
 
 

--- a/docs/powershell_library_code.md
+++ b/docs/powershell_library_code.md
@@ -206,6 +206,50 @@ Use this function to resolve a service tag, idrac IP, or an OME device name to i
             return $DeviceId
         }
 
+### Helpful device ID pattern 
+You frequently not only want to resolve device IDs, but check the output and then add the device IDs to a list of IDs. Below is a common pattern for this behavior.
+
+    $Targets = @()
+
+    if ($PSBoundParameters.ContainsKey('ServiceTags')) {
+        foreach ($ServiceTag in $ServiceTags) {
+            $Target = Get-DeviceId -OmeIpAddress $IpAddress -ServiceTag $ServiceTag
+            if ($Target -ne -1) {
+                $Targets += $Target
+            }
+            else {
+                Write-Error "Error - could not get ID for service tag $($ServiceTag)"
+                Exit
+            }
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('IdracIps')) {
+        foreach ($IdracIp in $IdracIps) {
+            $Target = Get-DeviceId $IpAddress -DeviceIdracIp $IdracIp
+            if ($Target -ne -1) {
+                $Targets += $Target
+            }
+            else {
+                Write-Error "Error - could not get ID for idrac IP $($IdracIp)"
+                Exit
+            }
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('DeviceNames')) {
+        foreach ($DeviceName in $DeviceNames) {
+            $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+            if ($Target -ne -1) {
+                $Targets += $Target
+            }
+            else {
+                Write-Error "Error - could not get ID for device name $($DeviceName)"
+                Exit
+            }
+        }
+    }
+
 ## Track a Job to Completion
 
 Track a job and wait for it to complete before continuing.

--- a/docs/python_library_code.md
+++ b/docs/python_library_code.md
@@ -84,11 +84,6 @@ This is used to perform any sort of interaction with a REST API resource. It inc
         else:
             count_data = requests.get(url, headers=authenticated_headers, verify=False).json()
 
-            if count_data.status_code == 400:
-                print("Received an error while retrieving data from %s:" % url)
-                pprint(count_data.json()['error'])
-                return []
-
         if 'value' in count_data:
             data = count_data['value']
         else:
@@ -201,8 +196,8 @@ Use this function to resolve a service tag, idrac IP, or an OME device name to i
     
         return device_id
 
-
-You frequently not only want to resolve them, but check the output and then add the device IDs to a list of IDs. Below is a common pattern for this behavior.
+### Helpful device ID pattern 
+You frequently not only want to resolve device IDs, but check the output and then add the device IDs to a list of IDs. Below is a common pattern for this behavior.
 
         target_ids = []
 


### PR DESCRIPTION
- Fixes a problem I introduced in my last commit to get-data where the API returns a dictionary instead of a list
- Completes #49/#52 by adding the ability to provide the ID of a discovery job from which to pull servers.
- Made a minor improvement to the PowerShell library code
- Updated add_device_to_static_group.py to use library code

Signed-off-by: Grant Curell <grant_curell@dell.com>