### PR TITLE
Do not require any passwords on the commandline, use getpass instead

### DIFF
--- a/Core/Python/add_device_to_static_group.py
+++ b/Core/Python/add_device_to_static_group.py
@@ -38,6 +38,7 @@ import sys
 from pprint import pprint
 from argparse import RawTextHelpFormatter
 from urllib.parse import urlparse
+from getpass import getpass
 
 try:
     import urllib3
@@ -232,7 +233,7 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for the OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for the OME Appliance")
     parser.add_argument("--groupname", "-g", required=True,
                         help="The name of the group to which you want to add servers.")
@@ -250,6 +251,9 @@ if __name__ == '__main__':
                         "manually from the UI by clicking on the job and pulling it from the URL. Ex: "
                         "https://192.168.1.93/core/console/console.html#/core/monitor/monitor_portal/jobsDetails?jobsId=14026")
     args = parser.parse_args()
+
+    if not args.password:
+        args.password = getpass()
 
     try:
 

--- a/Core/Python/add_members.py
+++ b/Core/Python/add_members.py
@@ -48,6 +48,7 @@ import json
 import random
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -251,12 +252,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument("--ip", "-i", required=True, help="MSM IP")
     parser.add_argument("--user", "-u", required=True, help="Username for MSM", default="root")
-    parser.add_argument("--password", "-p", required=True, help="Password for MSM")
+    parser.add_argument("--password", "-p", required=False, help="Password for MSM")
 
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass()
 
     try:
         auth_success, headers = authenticate_with_ome(ip_address, user_name,

--- a/Core/Python/edit_discovery_job.py
+++ b/Core/Python/edit_discovery_job.py
@@ -1,5 +1,5 @@
 #
-# 
+#
 # Copyright (c) 2020 Dell EMC Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 Script to update an existing discovery job in OME
 
 #### Description
-This script uses the OME REST API to update an existing discovery job(if found) with the credentials and also 
+This script uses the OME REST API to update an existing discovery job(if found) with the credentials and also
 it updates networkaddress if user passs iprange.
 For authentication X-Auth is used over Basic Authentication.
 Note that the credentials entered are not stored to disk.
@@ -38,6 +38,7 @@ import argparse
 import json
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -218,13 +219,13 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--jobNamePattern", required=True,
                         help="Job name pattern")
     parser.add_argument("--targetUserName", required=True,
                         help="Username to discover devices")
-    parser.add_argument("--targetPassword", required=True,
+    parser.add_argument("--targetPassword", required=False,
                         help="Password to discover devices")
     parser.add_argument("--targetIpAddresses",
                         help="ip address to modify discovery job config group")
@@ -232,9 +233,15 @@ if __name__ == '__main__':
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass("Password for OME Appliance: ")
     device_user_name = args.targetUserName
-    device_password = args.targetPassword
+    if args.targetPassword:
+        device_password = args.targetPassword
+    else:
+        device_password = getpass("Password to discover devices: ")
     ip_array = args.targetIpAddresses
     discovery_job_name = args.jobNamePattern
 

--- a/Core/Python/get_alerts.py
+++ b/Core/Python/get_alerts.py
@@ -61,6 +61,7 @@ import sys
 from argparse import RawTextHelpFormatter
 from pprint import pprint
 from urllib.parse import urlparse
+from getpass import getpass
 
 try:
     import urllib3
@@ -187,7 +188,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False, help="Username for the OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True, help="Password for the OME Appliance")
+    parser.add_argument("--password", "-p", required=False, help="Password for the OME Appliance")
     parser.add_argument("--top", required=False, help="Top records to return.")
     parser.add_argument('--pages', required=False, type=int,
                         help="You will generally not need to change this unless you are using a large value for top"
@@ -239,6 +240,9 @@ if __name__ == '__main__':
                         help="The description of the group on which you want to filter.")
 
     args = parser.parse_args()
+
+    if not args.password:
+        args.password = getpass()
 
     SEVERITY_TYPE = {'WARNING': '8', 'CRITICAL': '16', 'INFO': '2', 'NORMAL': '4', 'UNKNOWN': '1'}
     STATUS_TYPE = {'NORMAL': '1000', 'UNKNOWN': '2000', 'WARNING': '3000', 'CRITICAL': '4000', 'NOSTATUS': '5000'}

--- a/Core/Python/get_audit_logs.py
+++ b/Core/Python/get_audit_logs.py
@@ -18,7 +18,7 @@
 
 """
 #### Synopsis
-Retrieves the audit logs from a target OME instance and can either save them in an CSV on a fileshare or 
+Retrieves the audit logs from a target OME instance and can either save them in an CSV on a fileshare or
 print them to screen.
 
 #### Description
@@ -36,6 +36,7 @@ import sys
 from argparse import RawTextHelpFormatter
 from pprint import pprint
 from urllib.parse import urlparse
+from getpass import getpass
 
 try:
     import urllib3
@@ -176,13 +177,16 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False, help="Username for the OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True, help="Password for the OME Appliance")
+    parser.add_argument("--password", "-p", required=False, help="Password for the OME Appliance")
     parser.add_argument("--share", "-s", required=False,
                         help="A path to the share which you want to in format "
                              "\\\\<ip_address>\\<share_name>\\<file_name>")
     parser.add_argument("--smbuser", "-su", required=False, help="The username for SMB")
     parser.add_argument("--smbpass", "-sp", required=False, help="Password for SMB")
     args = parser.parse_args()
+
+    if not args.password:
+        args.password = getpass()
 
     try:
         headers = authenticate(args.ip, args.user, args.password)

--- a/Core/Python/get_chassis_inventory.py
+++ b/Core/Python/get_chassis_inventory.py
@@ -33,6 +33,7 @@ import argparse
 import csv
 import json
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -273,12 +274,16 @@ if __name__ == '__main__':
     parser.add_argument("--user", "-u", required=True,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass()
+
     try:
         auth_success, headers = authenticate_with_ome(ip_address, user_name,
                                                       password)

--- a/Core/Python/get_device_inventory.py
+++ b/Core/Python/get_device_inventory.py
@@ -34,6 +34,7 @@ Note that the credentials entered are not stored to disk.
 import argparse
 import json
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -109,7 +110,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", "-u", required=True,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--filterby", "-fby", required=True,
                         choices=('Id', 'Name', 'SvcTag'),
@@ -120,5 +121,8 @@ if __name__ == '__main__':
                         choices=('cpus', 'os', 'disks', 'controllers', 'memory'),
                         help="Get inventory by cpus/os/disks/controllers,memory")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     get_device_inventory(args.ip, args.user, args.password,
                          args.filterby, str(args.field), args.inventorytype)

--- a/Core/Python/get_device_list.py
+++ b/Core/Python/get_device_list.py
@@ -37,6 +37,7 @@ import json
 import os
 import sys
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import urllib3
 
@@ -192,7 +193,7 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--outformat", "-of", required=False, default="json",
                         choices=('json', 'csv'),
@@ -200,6 +201,8 @@ if __name__ == '__main__':
     parser.add_argument("--outpath", "-op", required=False, default="",
                         help="Path to output file")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     pool = urllib3.HTTPSConnectionPool(args.ip, port=443,
                                        cert_reqs='CERT_NONE', assert_hostname=False)

--- a/Core/Python/get_firmware_baselines.py
+++ b/Core/Python/get_firmware_baselines.py
@@ -33,6 +33,7 @@ import argparse
 import json
 from argparse import RawTextHelpFormatter
 from urllib.parse import urlparse
+from getpass import getpass
 
 import requests
 import urllib3
@@ -239,7 +240,7 @@ if __name__ == '__main__':
     PARSER.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     PARSER.add_argument("--user", "-u", required=False,
                         help="Username for the OME Appliance", default="admin")
-    PARSER.add_argument("--password", "-p", required=True,
+    PARSER.add_argument("--password", "-p", required=False,
                         help="Password for the OME Appliance")
     exclusive_group = PARSER.add_mutually_exclusive_group(required=False)
     exclusive_group.add_argument("--device-id", "-d", help="The device ID ")
@@ -247,6 +248,8 @@ if __name__ == '__main__':
     exclusive_group.add_argument("--idrac-ip", "-r", help="A device idrac IP")
     exclusive_group.add_argument("--device-name", "-n", help="The name of the device in OME")
     ARGS = PARSER.parse_args()
+    if not ARGS.password:
+        ARGS.password = getpass()
 
     try:
         headers = authenticate(ARGS.ip, ARGS.user, ARGS.password)

--- a/Core/Python/get_group_details.py
+++ b/Core/Python/get_group_details.py
@@ -33,6 +33,7 @@ Note that the credentials entered are not stored to disk.
 import argparse
 import json
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -131,9 +132,12 @@ if __name__ == '__main__':
     parser.add_argument("--user", "-u", required=True,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--groupinfo", "-g", required=True,
                         help="Group id/Name/Description - case insensitive")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     get_group_details(args.ip, args.user, args.password, str(args.groupinfo))

--- a/Core/Python/get_group_details_by_filter.py
+++ b/Core/Python/get_group_details_by_filter.py
@@ -34,6 +34,7 @@ Note that the credentials entered are not stored to disk.
 import argparse
 import json
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -108,7 +109,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", "-u", required=True,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--filterby", "-fby", required=True,
                         choices=('Name', 'Description'),
@@ -116,5 +117,8 @@ if __name__ == '__main__':
     parser.add_argument("--field", "-f", required=True,
                         help="Field to filter by (group name or description)")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     get_group_details(args.ip, args.user, args.password,
                       str(args.filterby), str(args.field))

--- a/Core/Python/get_group_list.py
+++ b/Core/Python/get_group_list.py
@@ -35,6 +35,7 @@ import json
 import pprint
 import sys
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -90,7 +91,10 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     get_group_list(args.ip, args.user, args.password)

--- a/Core/Python/get_identitypool_usage.py
+++ b/Core/Python/get_identitypool_usage.py
@@ -23,7 +23,7 @@ Script to get the list of virtual addresses in an Identity Pool
 
 #### Description
 This script uses the OME REST API to get a list of virtual addresses in an Identity Pool.
-Will export to a CSV file called IdentityPoolUsage.csv in the current directory. 
+Will export to a CSV file called IdentityPoolUsage.csv in the current directory.
 For authentication X-Auth is used over Basic Authentication
 Note that the credentials entered are not stored to disk.
 
@@ -40,6 +40,7 @@ import csv
 import json
 import os
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -194,7 +195,7 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--id", required=False,
                         help="Identity Pool Id")
@@ -202,5 +203,7 @@ if __name__ == '__main__':
                         help="Full path to CSV file")
 
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     get_device_list(args.ip, args.user, args.password, args.id, args.outfile)

--- a/Core/Python/get_report_list.py
+++ b/Core/Python/get_report_list.py
@@ -32,6 +32,7 @@ Note that the credentials entered are not stored to disk.
 import argparse
 import json
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -91,7 +92,10 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     get_report_list(args.ip, args.user, args.password)

--- a/Core/Python/invoke_discover_device.py
+++ b/Core/Python/invoke_discover_device.py
@@ -53,6 +53,7 @@ import sys
 import time
 from argparse import RawTextHelpFormatter
 from pprint import pprint
+from getpass import getpass
 
 try:
     import urllib3
@@ -344,11 +345,11 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--targetUserName", required=True,
                         help="Username to discover devices")
-    parser.add_argument("--targetPassword", required=True,
+    parser.add_argument("--targetPassword", required=False,
                         help="Password to discover devices")
     parser.add_argument("--deviceType", required=True,
                         choices=('server', 'chassis'),
@@ -361,9 +362,15 @@ if __name__ == '__main__':
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass("Password for OME Appliance: ")
     discover_user_name = args.targetUserName
-    discover_password = args.targetPassword
+    if args.targetPassword:
+        discover_password = args.targetPassword
+    else:
+        discover_password: getpass("Password to discover devices: ")
     ip_array = args.targetIpAddresses
     csv_file_path = args.targetIpAddrCsvFile
     device_type = args.deviceType

--- a/Core/Python/invoke_refresh_inventory.py
+++ b/Core/Python/invoke_refresh_inventory.py
@@ -36,6 +36,7 @@ from argparse import RawTextHelpFormatter
 from pprint import pprint
 from typing import List
 from urllib.parse import urlparse
+from getpass import getpass
 
 try:
     import urllib3
@@ -73,7 +74,7 @@ def authenticate(ome_ip_address: str, ome_username: str, ome_password: str) -> d
     if session_info.status_code == 201:
         authenticated_headers['X-Auth-Token'] = session_info.headers['X-Auth-Token']
         return authenticated_headers
-    
+
     print("There was a problem authenticating with OME. Are you sure you have the right username, password, "
           "and IP?")
     raise Exception("There was a problem authenticating with OME. Are you sure you have the right username, "
@@ -552,7 +553,7 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for the OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for the OME Appliance")
     parser.add_argument("--groupname", "-g", required=False, default="All Devices",
                         help="The name of the group containing the devices whose inventory you want to refresh. "
@@ -584,6 +585,8 @@ if __name__ == '__main__':
     parser.add_argument("--ignore-group", default=False, action='store_true', help="Used when you only want to run a"
                         " regular inventory and you do not want to provide a group.")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     try:
         headers = authenticate(args.ip, args.user, args.password)

--- a/Core/Python/invoke_report_execution.py
+++ b/Core/Python/invoke_report_execution.py
@@ -57,6 +57,7 @@ import json
 import os
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -214,7 +215,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", "-u", required=True,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--reportid", "-r", required=True,
                         help="a valid report id to execute")
@@ -225,6 +226,8 @@ if __name__ == '__main__':
                         help="Optional param - redirect the output to file")
 
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     try:
         REPORT_EXEC = OMEReportExecutor(args.ip, args.user,

--- a/Core/Python/invoke_retire_lead.py
+++ b/Core/Python/invoke_retire_lead.py
@@ -43,6 +43,7 @@ import json
 import random
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -224,12 +225,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument("--ip", "-i", required=True, help="MSM IP (Lead chassis)")
     parser.add_argument("--user", "-u", required=True, help="Username for MSM", default="root")
-    parser.add_argument("--password", "-p", required=True, help="Password for MSM")
+    parser.add_argument("--password", "-p", required=False, help="Password for MSM")
     args = parser.parse_args()
 
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass()
     try:
         auth_success, headers = authenticate_with_ome(ip_address, user_name,
                                                       password)

--- a/Core/Python/new_mcm_group.py
+++ b/Core/Python/new_mcm_group.py
@@ -51,6 +51,7 @@ import argparse
 import random
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -283,9 +284,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument("--ip", "-i", required=True, help="MSM IP")
     parser.add_argument("--user", "-u", required=True, help="Username for MSM", default="root")
-    parser.add_argument("--password", "-p", required=True, help="Password for MSM")
+    parser.add_argument("--password", "-p", required=False, help="Password for MSM")
     parser.add_argument("--groupname", "-g", required=True, help="A valid name for the group")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
+
     base_url = 'https://{0}/api'.format(args.ip)
 
     session_manager = SessionManager()

--- a/Core/Python/new_network.py
+++ b/Core/Python/new_network.py
@@ -36,6 +36,7 @@ import json
 import sys
 from argparse import RawTextHelpFormatter
 from os import path
+from getpass import getpass
 
 import requests
 import urllib3
@@ -136,7 +137,7 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--list-networks", "-ln", required=False, action='store_true',
                         help="List existing Networks")
@@ -151,6 +152,8 @@ if __name__ == '__main__':
 Name,Description,VlanMaximum,VlanMinimum,NetworkType
 VLAN 800,Description for VLAN 800,800,800,1""")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     headers = {'content-type': 'application/json'}
 

--- a/Core/Python/new_static_group.py
+++ b/Core/Python/new_static_group.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import sys
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 try:
     import urllib3
@@ -129,11 +130,13 @@ if __name__ == '__main__':
     parser.add_argument("--ip", "-i", required=True, help="OME Appliance IP")
     parser.add_argument("--user", "-u", required=False,
                         help="Username for OME Appliance", default="admin")
-    parser.add_argument("--password", "-p", required=True,
+    parser.add_argument("--password", "-p", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--groupname", "-g", required=True,
                         help="A valid name for the group")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     try:
         headers = authenticate(args.ip, args.user, args.password)

--- a/Core/Python/set_power_state.py
+++ b/Core/Python/set_power_state.py
@@ -40,6 +40,7 @@ import csv
 from pprint import pprint
 from urllib.parse import urlparse
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 try:
     import urllib3
@@ -401,7 +402,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--groupname", "-g", required=False, default="All Devices",
                         help="The name of the group containing the devices whose power state you want to change.")
@@ -419,6 +420,8 @@ if __name__ == '__main__':
                         choices=("POWER_ON", "POWER_OFF_GRACEFUL", "POWER_CYCLE", "POWER_OFF_NON_GRACEFUL",
                                  "MASTER_BUS_RESET"), help="Type of power operation you would like to perform.")
     args = parser.parse_args()
+    if not args.password:
+        args.password = getpass()
 
     POWER_STATE_MAPPING = {
         "Power On": "2",

--- a/Core/Python/set_system_configuration.py
+++ b/Core/Python/set_system_configuration.py
@@ -31,6 +31,7 @@ import json
 import sys
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import requests
 import urllib3
@@ -299,7 +300,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--sourceid", type=int, required=True,
                         help="Source device id to clone the elements from the device")
@@ -315,7 +316,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass()
     DEVICE_ID = args.sourceid
     TARGET_IDS = []
     FQDDS = None

--- a/Core/Python/update_firmware_using_catalog.py
+++ b/Core/Python/update_firmware_using_catalog.py
@@ -34,6 +34,7 @@ import os
 import sys
 import time
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 
 import urllib3
 
@@ -642,7 +643,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--updateactions", required=True, nargs="*",
                         help="Update action required",
@@ -670,16 +671,21 @@ if __name__ == '__main__':
     parser.add_argument("--refresh", required=False, default=False, type=str2bool,
                         help="refresh/create online catalog or use existing one.")
     args = parser.parse_args()
-    if args.repotype == 'CIFS' and (args.reposourceip is None or args.catalogpath is None
-                                    or args.repouser is None or args.repopassword is None):
-        parser.error("CIFS repository requires --reposourceip, --catalogpath, "
-                     "--repouser and --repopassword.")
+    if args.repotype == 'CIFS':
+        if args.reposourceip is None or args.catalogpath is None or args.repouser is None:
+            parser.error("CIFS repository requires --reposourceip, --catalogpath, "
+                         "--repouser and --repopassword.")
+        if not args.repopassword:
+            args.repopassword = getpass("Password for CIFS repository: ")
     if args.repotype == 'NFS' and (args.reposourceip is None or args.catalogpath is None):
         parser.error("NFS repository requires --reposourceip, --catalogpath.")
 
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass("Password for OME Appliance: ")
     UPDATE_ACTIONS = set()
     for action in args.updateactions:
         if action == "flash-all":

--- a/Core/Python/update_installed_firmware_with_dup.py
+++ b/Core/Python/update_installed_firmware_with_dup.py
@@ -58,6 +58,7 @@ import copy
 import time
 import argparse
 from argparse import RawTextHelpFormatter
+from getpass import getpass
 import json
 import urllib3
 import requests
@@ -332,7 +333,7 @@ if __name__ == '__main__':
     parser.add_argument("--user", required=False,
                         help="Username for OME Appliance",
                         default="admin")
-    parser.add_argument("--password", required=True,
+    parser.add_argument("--password", required=False,
                         help="Password for OME Appliance")
     parser.add_argument("--dupfile", required=True,
                         help="Path to DUP file that will be flashed")
@@ -344,7 +345,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     ip_address = args.ip
     user_name = args.user
-    password = args.password
+    if args.password:
+        password = args.password
+    else:
+        password = getpass()
     DUP_FILE = args.dupfile
     PARAM_MAP = {}
     TARGET_DATA = []


### PR DESCRIPTION
Requiring a password on the commandline might expose this to other users on the same system via `/proc` or `ps`. This mitigates the risk as Users of the python scripts do not need to state the password on the command line but are asked for the necessary string.

Additionally this will help with secure Passwords containing special characters which might be otherwise be parsed by the shell or requiring escaping. (Like using `pa"ss'w#ord!`)

Replaces #121 and Fixeѕ #118