### PR TITLE
Update-FirmwareUsingCatalog.ps1: Fixed minor bug

### DIFF
--- a/Core/PowerShell/Update-FirmwareUsingCatalog.ps1
+++ b/Core/PowerShell/Update-FirmwareUsingCatalog.ps1
@@ -87,7 +87,7 @@ param(
 
     [Parameter(Mandatory)]
     [ValidateSet('DELL_ONLINE', 'NFS', 'CIFS')]
-    [String]$RepoType,
+    [String]$RepoType = "DELL_ONLINE",
 
     [Parameter(Mandatory = $false)]
     [System.Net.IPAddress] $ResourceIp,
@@ -757,6 +757,7 @@ try {
     $CatalogId = $null
     $RepoId = $null
     $CatalogRepositorySource = $null
+    $SLEEPINTERVAL = 20
     if ($RepoType -eq 'DELL_ONLINE') {
         $CatalogRepositorySource = "downloads.dell.com"
     }

--- a/Core/Python/invoke_discover_device.py
+++ b/Core/Python/invoke_discover_device.py
@@ -434,7 +434,7 @@ if __name__ == '__main__':
             if job_id != -1:
                 track_job_to_completion(ip_address, headers, job_id)
             else:
-                print("There was a problem retrieving the job ID for discovering. Exiting.")
+                print("There was a problem retrieving the job ID for discovery. Exiting.")
         else:
             print("unable to discover devices ", discovery_resp.text)
 


### PR DESCRIPTION
- Update-FirmwareUsingCatalog.ps1 was missing a static declaration.
- Updated RepoType to default to DELL_ONLINE since the other two types aren't supported.

Signed-off-by: Grant Curell <grant_curell@dell.com>