### PR TITLE
Invoke-ReportExecution.ps1: Performed overhaul

### DIFF
--- a/Core/PowerShell/Get-ReportList.ps1
+++ b/Core/PowerShell/Get-ReportList.ps1
@@ -160,12 +160,8 @@ function Get-Data {
 }
 
 Try {
-  $BaseUri = "https://$($IpAddress)"
-  $ReportUrl = $BaseUri + "/api/ReportService/ReportDefs"
-  $NextLinkUrl = $null
-  $Type = "application/json"
 
-  Get-Data $ReportUrl
+  Get-Data "https://$($IpAddress)/api/ReportService/ReportDefs"
 
 }
 catch {

--- a/Core/PowerShell/Invoke-ReportExecution.ps1
+++ b/Core/PowerShell/Invoke-ReportExecution.ps1
@@ -1,5 +1,8 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
+_author_ = Grant Curell <grant_curell@dell.com>
 
 Copyright (c) 2021 Dell EMC Corporation
 
@@ -7,7 +10,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,235 +20,468 @@ limitations under the License.
 #>
 
 <#
- .SYNOPSIS
-   Script to invoke execution of a report in OME 
+  .SYNOPSIS
+    Script to invoke execution of a report in OME 
 
- .DESCRIPTION
+  .DESCRIPTION
+    This script uses the OME REST API to execute a pre-canned
+    report (this can include custom reports defined by the user)
+    and tracks completion of the report. On completion the report
+    result is printed to screen.
 
-   This script uses the OME REST API to execute a pre-canned
-   report (this can include custom reports defined by the user)
-   and tracks completion of the report. On completion the report
-   result is printed to screen.
+  .PARAMETER IpAddress
+    This is the IP address of the OME Appliance
 
- .PARAMETER IpAddress
-   This is the IP address of the OME Appliance
- .PARAMETER Credentials
-   Credentials used to talk to the OME Appliance
- .PARAMETER ReportId
-   ID of the report to be run
+  .PARAMETER Credentials
+    Credentials used to talk to the OME Appliance
+
+  .PARAMETER ReportId
+    ID of the report to run. You must provide either a report name or a report ID.
+
+  .PARAMETER ReportName
+    The name of the report which you would like to run. You must provide either a report name or
+    a report ID.
+
+  .PARAMETER GroupName
+    (Optional) The name of a specific group against which you want to run the report.
+
+  .PARAMETER GroupId
+    (Optional) The ID of a group against which you want to run a specific report.
+
+  .PARAMETER OutputFilePath
+    (Optional) If you would like the output to go to a CSV file you can specify the filename here.
+    If this is not specified it will instead output to the terminal.
    
- .EXAMPLE
-   $cred = Get-Credential
-   .\Invoke-ReportExecution.ps1 -IpAddress "10.xx.xx.xx" -Credentials $cred -ReportId 10043
+  .EXAMPLE
+    $cred = Get-Credential
+    .\Invoke-ReportExecution.ps1 -IpAddress "10.xx.xx.xx" -Credentials $cred -ReportId 10043 -OutputFilePath test.csv
 
- .EXAMPLE
-   .\Invoke-ReportExecution.ps1 -IpAddress "10.xx.xx.xx" -ReportId 10043
-   In this instance you will be prompted for credentials to use to
-   connect to the appliance
+  .EXAMPLE
+    .\Invoke-ReportExecution.ps1 -IpAddress "10.xx.xx.xx" -ReportName SomeReport
+    In this instance you will be prompted for credentials to use to
+    connect to the appliance
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory)]
-    [System.Net.IPAddress] $IpAddress,
+  [Parameter(Mandatory)]
+  [System.Net.IPAddress] $IpAddress,
 
-    [Parameter(Mandatory)]
-    [pscredential] $Credentials,
+  [Parameter(Mandatory)]
+  [pscredential] $Credentials,
 
-    [Parameter(Mandatory)]
-    [uint64] $ReportId,
+  [Parameter(Mandatory = $false)]
+  [uint64] $ReportId,
 
-    [Parameter(Mandatory = $false)]
-    [uint64] $GroupId = 0,
-    
-    [Parameter(Mandatory = $false)]
-    [ValidateSet("csv", "table")]
-    [string]$OutputFormat = "csv",
-    
-    [Parameter(Mandatory = $false)]
-    [string]$OutputFilePath = ""    
+  [Parameter(Mandatory = $false)]
+  [string] $ReportName,
+
+  [Parameter(Mandatory = $false)]
+  [string] $GroupName,
+
+  [Parameter(Mandatory = $false)]
+  [uint64] $GroupId,
+  
+  [Parameter(Mandatory = $false)]
+  [string]$OutputFilePath
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
+function Get-Data {
+  <#
+  .SYNOPSIS
+    Used to interact with API resources
 
-function Get-uniquefilename {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [System.IO.FileInfo] $filepath,
+  .DESCRIPTION
+    This function retrieves data from a specified URL. Get requests from OME return paginated data. The code below
+    handles pagination. This is the equivalent in the UI of a list of results that require you to go to different
+    pages to get a complete listing.
+
+  .PARAMETER Url
+    The API url against which you would like to make a request
+
+  .PARAMETER OdataFilter
+    An optional parameter for providing an odata filter to run against the API endpoint.
+
+  .PARAMETER MaxPages
+    The maximum number of pages you would like to return
+
+  .INPUTS
+    None. You cannot pipe objects to Get-Data.
+
+  .OUTPUTS
+    dict. A dictionary containing the results of the API call or an empty dictionary in the case of a failure
+
+  #>
+
+  [CmdletBinding()]
+  param (
+
+    [Parameter(Mandatory)]
+    [string]
+    $Url,
+
+    [Parameter(Mandatory = $false)]
+    [string]
+    $OdataFilter,
+
+    [Parameter(Mandatory = $false)]
+    [int]
+    $MaxPages = $null
+  )
+
+  $Data = @()
+  $NextLinkUrl = $null
+  try {
+
+    if ($PSBoundParameters.ContainsKey('OdataFilter')) {
+      $CountData = Invoke-RestMethod -Uri $Url"?`$filter=$($OdataFilter)" -Method Get -Credential $Credentials -SkipCertificateCheck
+
+      if ($CountData.'@odata.count' -lt 1) {
+        Write-Error "No results were found for filter $($OdataFilter)."
+        return @{}
+      } 
+    }
+    else {
+      $CountData = Invoke-RestMethod -Uri $Url -Method Get -Credential $Credentials -ContentType $Type `
+        -SkipCertificateCheck
+    }
+
+    if ($null -ne $CountData.'value') {
+      $Data += $CountData.'value'
+    }
+    else {
+      $Data += $CountData
+    }
     
-        [Parameter(Mandatory)]
-        [String] $formatextension
-    )
+    if ($CountData.'@odata.nextLink') {
+      $NextLinkUrl = "https://$($IpAddress)$($CountData.'@odata.nextLink')"
+    }
 
-    if (Test-Path -LiteralPath $filepath -PathType Container) {
-        Write-Error "Unable to get the file name, please provide the filename"
-    }
-    else {
-        $folder = Split-Path -Path ([io.path]::GetFullPath($filepath)) -Parent
-        $formatfilename = $filepath.BaseName
-        $i = 1
-        while (Test-Path $filepath) {
-            $filename = $formatfilename + "($i)"
-            $newfilename = $filename + "." + $formatextension
-            $filepath = Join-Path $folder $newfilename
-            $i++
+    $i = 1
+    while ($NextLinkUrl) {
+      if ($MaxPages) {
+        if ($i -ge $MaxPages) {
+          break
         }
+        $i = $i + 1
+      }
+      
+      $NextLinkData = Invoke-RestMethod -Uri "$($NextLinkUrl)" -Method Get -Credential $Credentials `
+      -ContentType $Type -SkipCertificateCheck
+          
+      if ($null -ne $NextLinkData.'value') {
+        $Data += $NextLinkData.'value'
+      }
+      else {
+        $Data += $NextLinkData
+      }    
+      
+      if ($NextLinkData.'@odata.nextLink') {
+        $NextLinkUrl = "https://$($IpAddress)$($NextLinkData.'@odata.nextLink')"
+      }
+      else {
+        $NextLinkUrl = $null
+      }
     }
-    return $filepath
+
+    return $Data
+
+  }
+  catch [System.Net.Http.HttpRequestException] {
+    Write-Error "There was a problem connecting to OME or the URL supplied is invalid. Did it become unavailable?"
+    return @{}
+  }
+
 }
 
-function Format-OutputInfo($IpAddress, $Headers, $Type, $ReportId) {
-    $BaseUri = "https://$($IpAddress)"
-    $ReportDeets = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))"
-    $NextLinkUrl = $null
-    $OutputArray = @()
-    $ColumnNames = @()
-    [psobject[]]$objlist = @()
-    $DeetsResp = Invoke-WebRequest -Uri $ReportDeets -Headers $Headers -Method Get -ContentType $Type
-    if ($DeetsResp.StatusCode -eq 200) {
-        $DeetsInfo = $DeetsResp.Content | ConvertFrom-Json
-        $ColumnNames = $DeetsInfo.ColumnNames.Name
-        Write-Verbose "Extracting results for report ($($ReportId))"
-        $ResultUrl = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))/ReportResults/ResultRows"
-        
-        $RepResult = Invoke-WebRequest -Uri $ResultUrl -Method Get -Headers $Headers -ContentType $Type
-        if ($RepResult.StatusCode -eq 200) {
-            $RepInfo = $RepResult.Content | ConvertFrom-Json
-            $totalRepResults = [int]($RepInfo.'@odata.count')
-            if ($totalRepResults -gt 0) {
-                $ReportResultList = $RepInfo.Value
-                if ($RepInfo.'@odata.nextLink') {
-                    $NextLinkUrl = $BaseUri + $RepInfo.'@odata.nextLink'
-                }
-                while ($NextLinkUrl) {
-                    $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
-                    if ($NextLinkResponse.StatusCode -eq 200) {
-                        $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
-                        $ReportResultList += $NextLinkData.'value'
-                        if ($NextLinkData.'@odata.nextLink') {
-                            $NextLinkUrl = $BaseUri + $NextLinkData.'@odata.nextLink'
-                        }
-                        else {
-                            $NextLinkUrl = $null
-                        }
-                    }
-                    else {
-                        Write-Error "Unable to get full set of report results"
-                        $NextLinkUrl = $null
-                    }
-                }
-                foreach ($value in $ReportResultList) {
-                    $resultVals = $value.Values
+function Invoke-TrackJobToCompletion {
+  <#
+  .SYNOPSIS
+  Tracks a job to either completion or a failure within the job.
 
-                    $tempHash = @{}
-                    for ($i = 0; $i -lt $ColumnNames.Count; $i++) {
-                        $tempHash[$ColumnNames[$i]] = $resultVals[$i]
-                    }
-                    $outputArray += , $tempHash
-                    if ($outputformat -eq "csv") {
-                        $objlist += New-Object -TypeName psobject -Property $tempHash
-                    }
-                }
-                if ($outputformat -eq "csv") {
-                    $filepath = Get-uniquefilename -filepath $outputfilepath -formatextension "csv"
-                    $objlist | Export-Csv -Path $filepath
-                }
-                else {
-                    $outputArray.Foreach( { [PSCustomObject]$_ }) | Format-Table -AutoSize
-                }
-            }
-            else {
-                Write-Warning "No result data retrieved from $($IpAddress) for report ($($ReportId))"
-            }
-        }
-        else {
-            Write-Warning "Unable to get report results for $($ReportId) from $($IpAddress)"
-        }
-    }
-    else {
-        Write-Warning "Unable to create mapping for report data columns"
-    }
+  .PARAMETER OmeIpAddress
+  The IP address of the OME server
+
+  .PARAMETER JobId
+  The ID of the job which you would like to track
+
+  .PARAMETER MaxRetries
+  (Optional) The maximum number of times the function should contact the server to see if the job has completed
+
+  .PARAMETER SleepInterval
+  (Optional) The frequency with which the function should check the server for job completion
+
+  .OUTPUTS
+  True if the job completed successfully or completed with errors. Returns false if the job failed.
+
+  #>
+
+  [CmdletBinding()]
+  param (
+
+      [Parameter(Mandatory)]
+      [System.Net.IPAddress]
+      $OmeIpAddress,
+
+      [Parameter(Mandatory)]
+      [int]
+      $JobId,
+
+      [Parameter(Mandatory = $false)]
+      [int]
+      $MaxRetries = 20,
+
+      [Parameter(Mandatory = $false)]
+      [int]
+      $SleepInterval = 60
+  )
+
+  $FAILEDJOBSTATUSES = @('Failed', 'Warning', 'Aborted', 'Paused', 'Stopped', 'Canceled')
+  $Ctr = 0
+  do {
+      $Ctr++
+      Start-Sleep -Seconds $SleepInterval
+      $JOBSVCURL = "https://$($IpAddress)/api/JobService/Jobs($($JobId))"
+      $JobData = Get-Data $JOBSVCURL
+
+      if ($null -eq $JobData) {
+          Write-Error "Something went wrong tracking the job data. 
+          Try checking jobs in OME to see if the job is running."
+          return $false
+      }
+
+      $JobStatus = $JobData.LastRunStatus.Name
+      Write-Host "Iteration $($Ctr): Status of $($JobId) is $($JobStatus)"
+      if ($JobStatus -eq 'Completed') {
+          ## Completed successfully
+          Write-Host "Job completed successfully!"
+          break
+      }
+      elseif ($FAILEDJOBSTATUSES -contains $JobStatus) {
+          Write-Warning "Job failed"
+          $JOBEXECURL = "$($JOBSVCURL)/ExecutionHistories"
+          $ExecRespInfo = Invoke-RestMethod -Uri $JOBEXECURL -Method Get -Credential $Credentials -SkipCertificateCheck
+          $HistoryId = $ExecRespInfo.value[0].Id
+          $HistoryResp = Invoke-RestMethod -Uri "$($JOBEXECURL)($($HistoryId))/ExecutionHistoryDetails" -Method Get `
+                                          -ContentType $Type -Credential $Credentials -SkipCertificateCheck
+          Write-Host "------------------- ERROR -------------------"
+  Write-Host $HistoryResp.value
+  Write-Host "------------------- ERROR -------------------"
+          return $false
+      }
+      else { continue }
+  } until ($Ctr -ge $MaxRetries)
+
+  if ($Ctr -ge $MaxRetries) {
+      Write-Warning "Job exceeded max retries! Check OME for details on what has hung."
+      return $false
+  }
+
+  return $true
 }
+
+function Read-Confirmation {
+  <#
+  .SYNOPSIS
+    Prompts a user with a yes or no question
+
+  .DESCRIPTION
+    Prompts a user with a yes or no question. The question text should include something telling the user
+    to type y/Y/Yes/yes or N/n/No/no
+
+  .PARAMETER QuestionText
+    The text which you want to display to the user
+
+  .OUTPUTS
+    Returns true if the user enters yes and false if the user enters no
+  #>
+  [CmdletBinding()]
+  param (
+
+      [Parameter(Mandatory)]
+      [string]
+      $QuestionText
+  )
+  do {
+      $Confirmation = (Read-Host $QuestionText).ToUpper()
+  } while ($Confirmation -ne 'YES' -and $Confirmation -ne 'Y' -and $Confirmation -ne 'N' -and $Confirmation -ne 'NO')
+
+  if ($Confirmation -ne 'YES' -and $Confirmation -ne 'Y') {
+      return $false
+  }
+
+  return $true
+}
+
+function Confirm-IsValid {
+  <#
+  .SYNOPSIS
+    Tests whether a filepath is valid or not.
+
+  .DESCRIPTION
+    Performs different tests depending on whether you are testing a file for the ability to read
+    (InputFilePath) or write (OutputFilePath)
+
+  .PARAMETER OutputFilePath
+    The path to an output file you want to test
+
+  .PARAMETER InputFilePath
+    The path to an input file you want to test
+
+  .OUTPUTS
+    Returns true if the path is valid and false if it is not
+  #>
+  [CmdletBinding()]
+  param (
+
+    [Parameter(Mandatory = $false)]
+    [string]
+    $OutputFilePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]
+    $InputFilePath
+  )
+
+  if ($PSBoundParameters.ContainsKey('InputFilePath') -and $PSBoundParameters.ContainsKey('OutputFilePath')) {
+    Write-Error "You can only provide either an InputFilePath or an OutputFilePath."
+    Exit
+  }
+
+  # Some of the tests are the same - we can use the same variable name
+  if ($PSBoundParameters.ContainsKey('InputFilePath')) {
+    $OutputFilePath = $InputFilePath
+  }
+
+  if ($PSBoundParameters.ContainsKey('InputFilePath')) {
+    if (-not $(Test-Path -Path $InputFilePath -PathType Leaf)) {
+      Write-Error "The file $($InputFilePath) does not exist."
+      return $false
+    }
+  }
+  else {
+    if (Test-Path -Path $OutputFilePath -PathType Leaf) {
+      if (-not $(Read-Confirmation "$($OutputFilePath) already exists. Do you want to continue? (Y/N)")) {
+        return $false
+      } 
+    }
+  }
+
+  $ParentPath = $(Split-Path -Path $OutputFilePath -Parent)
+  if ($ParentPath -ne "") {
+    if (-not $(Test-Path -PathType Container $ParentPath)) {
+      Write-Error "The path '$($OutputFilePath)' does not appear to be valid."
+      return $false
+    }
+  }
+
+  if (Test-Path $(Split-Path -Path $OutputFilePath -Leaf) -PathType Container) {
+    Write-Error "You must provide a filename as part of the path. It looks like you only provided a folder in $($OutputFilePath)!"
+    return $false
+  }
+
+  return $true
+}
+
 
 Try {
-    if (($outputformat -like "csv") -and ($outputfilepath -eq "")) {
-        Write-Error "CSV Filepath is not provided." -ErrorAction Stop
+
+  ####################################
+  # Lookup and run the target report #
+  ####################################
+
+  $ExecRepUrl = "https://$($IpAddress)/api/ReportService/Actions/ReportService.RunReport"
+  $Type = "application/json"
+
+  if ($PSBoundParameters.ContainsKey('OutputFilePath')) {
+    if (-not $(Confirm-IsValid -OutputFilePath $OutputFilePath) ) {
+      Exit
     }
+  }
 
-    Set-CertPolicy
-    $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
-    $ExecRepUrl = "https://$($IpAddress)/api/ReportService/Actions/ReportService.RunReport"
-    $Type = "application/json"
-    $UserName = $Credentials.username
-    $Password = $Credentials.GetNetworkCredential().password
-    $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
-    $RepPayload = @{"ReportDefId" = $ReportId; "FilterGroupId" = $GroupId } | ConvertTo-Json
-    $Headers = @{}
-    $JobDoneStatus = @("completed", "failed", "warning", "aborted", "canceled")
-    $RetryCount = 90 
+  if ($PSBoundParameters.ContainsKey('ReportName')) {
+    Write-Host "Looking up the report with name $($ReportName)"
+    $ReportData = Get-Data -Url "https://$($IpAddress)/api/ReportService/ReportDefs" -OdataFilter "Name eq `'$($ReportName)`'"
 
-    
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
-    if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
-        ## Successfully created a session - extract the auth token from the response
-        ## header and update our headers for subsequent requests
-        $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $ReportResp = Invoke-WebRequest -Uri $ExecRepUrl -Method Post -Headers $Headers -ContentType $Type -Body $RepPayload
-        if ($ReportResp.StatusCode -eq 200) {
-            $JobId = $ReportResp.Content
-            $JobUrl = "https://$($IpAddress)/api/JobService/Jobs($($JobId))"
-            $CurrJobStatus = ""
-            $Counter = 0
-            do {
-                $Counter++
-                Write-Host "Polling report status ... "
-                Start-Sleep -Seconds 10                
-                $JobResp = Invoke-WebRequest -Uri $JobUrl -Method Get -Headers $Headers -ContentType $Type
-                if ($JobResp.StatusCode -eq 200) {
-                    $JobInfo = $JobResp.Content | ConvertFrom-Json
-                    $CurrJobStatus = [string]($JobInfo.LastRunStatus.Name).ToLower()
-                    Write-Verbose "Job status is $($CurrJobStatus)"
-                }
-                else {
-                    Write-Warning "Unable to determine job status - Iteration $($Counter)"
-                }
-
-            } until ( ($JobDoneStatus -contains $CurrJobStatus) -or ($Counter -gt $RetryCount))
-            if ($CurrJobStatus -eq 'completed') {
-                Format-OutputInfo $IpAddress $Headers $Type $ReportId
-            }
-            else {
-                Write-Warning "Job $($JobId) failed ... Unable to run report"
-            }
-        }
-        else {
-            Write-Warning "Unable to retrieve reports from $($IpAddress)"
-        }
+    if ($ReportData.Count -gt 0) {
+      $ReportId = $ReportData.Id
     }
     else {
-        Write-Error "Unable to create a session with appliance $($IpAddress)"
+      Write-Error "Could not find a report with the name $($ReportName). Exiting." -ErrorAction Stop
     }
+  }
+
+  if ($PSBoundParameters.ContainsKey('GroupName')) {
+    Write-Host "Resolving group name $($GroupName) to a group ID..."
+
+    $GroupData = Get-Data "https://$($IpAddress)/api/GroupService/Groups" "Name eq '$($GroupName)'"
+
+    if ($null -eq $GroupData) {
+        Write-Error "We were unable to retrieve the GroupId for group name $($GroupName). Is the name correct?"
+        Exit
+    }
+
+    Write-Host "$($GroupName)'s ID is $($GroupData.'Id')"
+    $GroupId = $GroupData.'Id'
+  }
+  elseif ( -not $PSBoundParameters.ContainsKey('GroupId')) {
+    # This means do not use a GroupId in the report lookup
+    $GroupId = 0
+  }
+
+  $RepPayload = @{"ReportDefId" = $ReportId; "FilterGroupId" = $GroupId } | ConvertTo-Json
+
+  try {
+    $ReportJobId = Invoke-RestMethod -Uri $ExecRepUrl -Credential $Credentials -Method POST -Body $RepPayload `
+    -ContentType $Type -SkipCertificateCheck
+  }
+  catch [Microsoft.PowerShell.Commands.HttpResponseException] {
+    Write-Error "The post responded with a status code of $($_.Exception.Response.StatusCode). This typically means the Report ID was invalid. Are you sure $($ReportId) is a valid ID?"
+    Exit
+  }
+  
+  Write-Host "Report job successfully submitted. Waiting for completion..."
+  if (-not $(Invoke-TrackJobToCompletion -OmeIpAddress $IpAddress -JobId $ReportJobId -SleepInterval 10 -MaxRetries 90)) {
+    Write-Error "Something went wrong while running the report or it took too long. Exiting." -ErrorAction Stop
+  }
+  
+  #######################################################
+  # Output the file to either CSV or the command prompt #
+  #######################################################
+
+  Write-Host "Exporting report..."
+
+  $BaseUri = "https://$($IpAddress)"
+  $ReportDetails = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))"
+  $OutputArray = @()
+  $ColumnNames = @()
+  [psobject[]]$ObjList = @()
+  $ReportInfo = Get-Data $ReportDetails
+  $ColumnNames = $ReportInfo.ColumnNames.Name
+  Write-Verbose "Extracting results for report ($($ReportId))"
+  $ResultUrl = $BaseUri + "/api/ReportService/ReportDefs($($ReportId))/ReportResults/ResultRows"
+
+  $ReportResultList = Get-Data $ResultUrl
+  foreach ($value in $ReportResultList) {
+    $ResultValues = $value.Values
+
+    $TempHash = @{}
+    for ($i = 0; $i -lt $ColumnNames.Count; $i++) {
+      $TempHash[$ColumnNames[$i]] = $ResultValues[$i]
+    }
+    $OutputArray += , $TempHash
+    if ($PSBoundParameters.ContainsKey('OutputFilePath')) {
+      $ObjList += New-Object -TypeName psobject -Property $TempHash
+    }
+  }
+  if ($PSBoundParameters.ContainsKey('OutputFilePath')) {
+    $ObjList | Export-Csv -Path $OutputFilePath
+  }
+  else {
+    foreach ($ReportItem in $OutputArray) {
+      $ReportItem | Format-Table -AutoSize
+    }
+  }
 }
 catch {
-    Write-Error "Exception occured at line $($_.InvocationInfo.ScriptLineNumber) - $($_.Exception.Message)"
+  Write-Error "Exception occured at line $($_.InvocationInfo.ScriptLineNumber) - $($_.Exception.Message)"
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,6 +49,7 @@ We are working to standardize the repository. Any help would be welcomed with [u
 ## PowerShell
 
 - Must be tested and run against PowerShell 7. Scripts should include `#Requires -Version 7` at the top to indicate this requirement.
+- All status messages should use `Write-Host` so that piping between scripts functions correctly. Ex: "Starting up the engines..."
 - Function names must use [approved PowerShell verbs](https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-7)
 - Variable names should use CamelCaseLikeThis for regular variable names and ALLCAPS for constants. 
 - We suggest for development you use [Visual Studio Code](https://code.visualstudio.com/download). It provides a `Format Document` function which automatically updates your PowerShell code to follow best practices. If you would rather use something else you can use [Get-FirmwareBaselines.ps1](Core/PowerShell/Get-FirmwareBaselines.ps1) as a reference for our preferred PowerShell coding practices.

--- a/docs/python_library_code.md
+++ b/docs/python_library_code.md
@@ -1,5 +1,15 @@
 # Python Library Code
 
+- [Python Library Code](#python-library-code)
+  - [Authenticating to an OME Instance](#authenticating-to-an-ome-instance)
+  - [Interact with an API Resource](#interact-with-an-api-resource)
+  - [Resolve a device to its ID](#resolve-a-device-to-its-id)
+    - [Helpful device ID pattern](#helpful-device-id-pattern)
+    - [Get Group ID by Name](#get-group-id-by-name)
+  - [Track a Job to Completion](#track-a-job-to-completion)
+  - [Pattern for Getting a Group's ID and a List of Devices in the Group](#pattern-for-getting-a-groups-id-and-a-list-of-devices-in-the-group)
+  - [Printing a Dictionary to a CSV File](#printing-a-dictionary-to-a-csv-file)
+
 ## Authenticating to an OME Instance
 
 Used to create a session to OME. You can then pass the resulting dictionary headers around to your various functions to authenticate.


### PR DESCRIPTION
- Now also accepts a report name which it will automatically resolve to an ID
- Addresses #60 and #63
- Fixes #177
- Added comments to the documentation for all variable names
- Added the ability to provide a group name for filter groups instead of group id
- Made it so OutputFilePath is no longer required nor do you have to specify the type. If the OutputFilePath argument is specified it will output to CSV otherwise it will output to the current command prompt
- Added functions for yes no prompts and validating files to the powershell library code
- Added TOCs to the library code for PowerShell and Python to make them easier to use

Signed-off-by: Grant Curell <grant_curell@dell.com>