### PR TITLE
Invoke-ReportExecution.ps1: Patch #190

### DIFF
--- a/Core/PowerShell/Invoke-ReportExecution.ps1
+++ b/Core/PowerShell/Invoke-ReportExecution.ps1
@@ -402,12 +402,21 @@ Try {
     Write-Host "Looking up the report with name $($ReportName)"
     $ReportData = Get-Data -Url "https://$($IpAddress)/api/ReportService/ReportDefs" -OdataFilter "Name eq `'$($ReportName)`'"
 
-    if ($ReportData.Count -gt 0) {
+    if ($ReportData.Count -eq 1) {
       $ReportId = $ReportData.Id
     }
-    else {
+    elseif ($ReportData.Count -gt 1) {
+      foreach ($Report in $ReportData) {
+        if ($Report.Name -eq $ReportName) {
+          $ReportId = $Report.Id
+        }
+      }
+    }
+
+    if ($ReportId -eq 0) {
       Write-Error "Could not find a report with the name $($ReportName). Exiting." -ErrorAction Stop
     }
+
   }
 
   if ($PSBoundParameters.ContainsKey('GroupName')) {


### PR DESCRIPTION
- Fixes #190.
- Addresses a problem where odata eq could return multiple matching Reports causing a crash

Signed-off-by: Grant Curell <grant_curell@dell.com>