### PR TITLE
Get-DeviceId function

### DIFF
--- a/PowerShell/Add-DeviceToStaticGroup.ps1
+++ b/PowerShell/Add-DeviceToStaticGroup.ps1
@@ -214,26 +214,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
-        [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [Parameter(ParameterSetName = "ServiceTag")]
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -324,7 +318,7 @@ try {
 
     if ($PSBoundParameters.ContainsKey('DeviceNames')) {
         foreach ($DeviceName in $DeviceNames -split ',') {
-            $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+            $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
             if ($Target -ne -1) {
                 $Targets += $Target
             }

--- a/PowerShell/Invoke-DiscoverDevice.ps1
+++ b/PowerShell/Invoke-DiscoverDevice.ps1
@@ -259,26 +259,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1

--- a/PowerShell/Invoke-ManageSupportAssistGroups.ps1
+++ b/PowerShell/Invoke-ManageSupportAssistGroups.ps1
@@ -319,26 +319,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -692,7 +686,7 @@ Try {
 
   if ($PSBoundParameters.ContainsKey('DeviceNames')) {
       foreach ($DeviceName in $DeviceNames -split ',') {
-          $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+          $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
           if ($Target -ne -1) {
               $Targets += $Target
           }

--- a/PowerShell/Invoke-RefreshInventory.ps1
+++ b/PowerShell/Invoke-RefreshInventory.ps1
@@ -233,26 +233,20 @@ function Get-DeviceId {
   
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -424,7 +418,7 @@ try {
 
     if ($PSBoundParameters.ContainsKey('DeviceNames')) {
         foreach ($DeviceName in $DeviceNames -split ',') {
-            $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+            $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
             if ($Target -ne -1) {
                 $Targets += $Target
             }

--- a/PowerShell/Set-PowerState.ps1
+++ b/PowerShell/Set-PowerState.ps1
@@ -227,26 +227,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -544,7 +538,7 @@ Try {
 
     if ($PSBoundParameters.ContainsKey('DeviceNames')) {
         foreach ($DeviceName in $DeviceNames -split ',') {
-            $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+            $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
             if ($Target -ne -1) {
                 $Targets += $Target
             }

--- a/PowerShell/Update-FirmwareUsingCatalog.ps1
+++ b/PowerShell/Update-FirmwareUsingCatalog.ps1
@@ -137,26 +137,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
         [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -640,7 +634,7 @@ try {
 
     if ($PSBoundParameters.ContainsKey('DeviceNames')) {
         foreach ($DeviceName in $DeviceNames -split ',') {
-            $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+            $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
             if ($Target -ne -1) {
                 $Targets += $Target
             }

--- a/docs/powershell_library_code.md
+++ b/docs/powershell_library_code.md
@@ -157,26 +157,20 @@ function Get-DeviceId {
 
     [CmdletBinding()]
     param (
-
         [Parameter(Mandatory)]
-        [System.Net.IPAddress]
-        $OmeIpAddress,
+        [System.Net.IPAddress]$OmeIpAddress,
 
         [Parameter(Mandatory = $false)]
-        [parameter(ParameterSetName = "ServiceTag")]
-        [string]
-        $ServiceTag,
+        [Parameter(ParameterSetName = "ServiceTag")]
+        [string]$ServiceTag,
 
         [Parameter(Mandatory = $false)]
-        [parameter(ParameterSetName = "DeviceIdracIp")]
-
-        [System.Net.IPAddress]
-        $DeviceIdracIp,
+        [Parameter(ParameterSetName = "DeviceIdracIp")]
+        [System.Net.IPAddress]$DeviceIdracIp,
 
         [Parameter(Mandatory = $false)]
-        [parameter(ParameterSetName = "DeviceName")]
-        [System.Net.IPAddress]
-        $DeviceName
+        [Parameter(ParameterSetName = "DeviceName")]
+        [string]$Devicename
     )
 
     $DeviceId = -1
@@ -257,7 +251,7 @@ if ($PSBoundParameters.ContainsKey('IdracIps')) {
 
 if ($PSBoundParameters.ContainsKey('DeviceNames')) {
     foreach ($DeviceName in $DeviceNames -split ',') {
-        $Target = Get-DeviceId $IpAddress -DeviceName $DeviceName
+        $Target = Get-DeviceId -OmeIpAddress $IpAddress -DeviceName $DeviceName
         if ($Target -ne -1) {
             $Targets += $Target
         }


### PR DESCRIPTION
- Param Block $DeviceName changed to be a string
- Get-DeviceId was missing the OmeIpAddress parameter

Signed off by: Gavin Ring (gavin.ring@dell.com)