### PR TITLE
Fix PowerShell 7 compatibility: replace TrustAllCertsPolicy with -SkipCertificateCheck

### DIFF
--- a/PowerShell/Add-MembersToMcmGroup.ps1
+++ b/PowerShell/Add-MembersToMcmGroup.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Vittalareddy Nanjareddy <vittalareddy_nanjare@Dell.com>
 
@@ -42,35 +44,13 @@ param(
     [pscredential] $Credentials
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 
 function Get-DiscoveredDomains($IpAddress, $Headers, $Role) {
     $DiscoveredDomains = @()
     $FilteredDiscoveredDomains = @()
     $TargetArray = @()
     $URL = "https://$($IpAddress)/api/ManagementDomainService/DiscoveredDomains"
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -115,7 +95,7 @@ function Add-AllMembersViaLead($IpAddress, $Headers) {
         $Payload = $StandaloneDomains
         $ManagementDomainURL = "https://$($IpAddress)/api/ManagementDomainService/Actions/ManagementDomainService.Domains"
         $Body = $Payload 
-        $Response = Invoke-WebRequest -Uri $ManagementDomainURL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $ManagementDomainURL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $ManagementData = $Response | ConvertFrom-Json
             $JobId = $ManagementData.'JobId'
@@ -145,7 +125,7 @@ function Assign-BackupLead($IpAddress, $Headers) {
         $TargetTempHash."Id" = $MemberId
         $TargetArray += $TargetTempHash
         $Body = ConvertTo-Json $TargetArray
-        $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $BackupLeadData = $Response | ConvertFrom-Json
             $JobId = $BackupLeadData.'JobId'
@@ -166,7 +146,7 @@ function Get-Domains($IpAddress, $Headers) {
     $Lead = $null
     $BackupLead = $null
     $URL = "https://$($IpAddress)/api/ManagementDomainService/Domains"
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -235,7 +215,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -248,12 +228,12 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -277,7 +257,6 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
 
 ## Script that does the work
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
     $UserName = $Credentials.username
@@ -286,13 +265,13 @@ Try {
     $Headers = @{}
 
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Write-Host "Successfully created session with $($IpAddress)"
         ## Sending in non-existent targets throws an exception with a "bad request"
         ## error. Doing some pre-req error checking as a result to validate input
-        ## This is a Powershell quirk on Invoke-WebRequest failing with an error
+        ## This is a Powershell quirk on Invoke-WebRequest -SkipCertificateCheck failing with an error
         # Create mcm group
         $JobId = 0
         $BackupLeadFound = $null

--- a/PowerShell/Deploy-Template.ps1
+++ b/PowerShell/Deploy-Template.ps1
@@ -1,4 +1,6 @@
-﻿<#
+﻿#Requires -Version 7
+
+<#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
 Copyright (c) 2022 Dell EMC Corporation
@@ -90,28 +92,6 @@ $MAX_RETRIES = 20
 $SLEEP_INTERVAL = 30
 
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 
 function Get-TemplatePayload($SourceId, $Component) {
     $template_payload = '{
@@ -181,7 +161,7 @@ function Get-TemplateStatus($IpAddress, $Headers, $Type, $TemplateId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -Method Get -Headers $Headers -ContentType $Type
+        $TemplateResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $TemplateUrl -Method Get -Headers $Headers -ContentType $Type
         if ($TemplateResponse.StatusCode -eq 200) {
             $TemplateInfo = $TemplateResponse.Content | ConvertFrom-Json
             $Status = [string]$TemplateInfo.value[0].Status
@@ -211,7 +191,7 @@ function New-IdentityPool($IpAddress, $Headers, $Type) {
     $IdentityPoolId = $null
     $IdentityPoolPayload = Get-IdentityPoolPayload | ConvertFrom-Json
     $IdentityPoolPayload = $IdentityPoolPayload | ConvertTo-Json -Depth 6
-    $IdentityResponse = Invoke-WebRequest -Uri $IdentityUrl -Method Post -Body $IdentityPoolPayload  -ContentType $Type -Headers $Headers
+    $IdentityResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $IdentityUrl -Method Post -Body $IdentityPoolPayload  -ContentType $Type -Headers $Headers
     if ( $IdentityResponse.StatusCode -eq 201) {
         $IdentityInfo = $IdentityResponse.Content | ConvertFrom-Json
         $IsSuccessful = $IdentityInfo.IsSuccessful
@@ -239,7 +219,7 @@ function Set-IdentitiesToTarget ($IpAddress, $Type, $Headers, $IdentityId, $Temp
     $payload.TemplateId = $TemplateId
     $payload.IdentityPoolId = $IdentityId
     $AssignIdentityPayload = $payload | ConvertTo-Json -Depth 6
-    $AssignIdentityResponse = Invoke-WebRequest -Uri $TemplateUrl -Method Post -Body $AssignIdentityPayload -ContentType $Type -Headers $Headers
+    $AssignIdentityResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $TemplateUrl -Method Post -Body $AssignIdentityPayload -ContentType $Type -Headers $Headers
     return $AssignIdentityResponse
 }
 
@@ -256,7 +236,7 @@ function Set-Configuration($IpAddress, $Type, $Headers, $TemplateId, $IdList) {
     $payload.TargetIds = $null
     $payload.TargetIds = @($IdList)
     $DeployTemplatePayload = $payload | ConvertTo-Json -Depth 6
-    $DeployResponse = Invoke-WebRequest -Uri $TemplateDeployUrl -Method Post -Body $DeployTemplatePayload -ContentType $Type -Headers $Headers
+    $DeployResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $TemplateDeployUrl -Method Post -Body $DeployTemplatePayload -ContentType $Type -Headers $Headers
     return $DeployResponse
 }
 
@@ -268,7 +248,7 @@ function Get-DeployTemplateStatus($IpAddress, $Type, $Headers, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -287,12 +267,12 @@ function Get-DeployTemplateStatus($IpAddress, $Type, $Headers, $JobId) {
                     Write-Warning " Failed to deploy template.... "
                 }
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -323,7 +303,7 @@ function Get-AssignedIdentities($IpAddress, $Type, $Headers, $TemplateId, $Targe
     $payload.TemplateId = $TemplateId
     $payload.BaseEntityId = $TargetId
     $AssignedIdentitiesPayload = $payload | ConvertTo-Json -Depth 6
-    $AssignedIdentitiesResponse = Invoke-WebRequest -Uri $TemplateUrl -Method Post -Body $AssignedIdentitiesPayload -ContentType $Type -Headers $Headers
+    $AssignedIdentitiesResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $TemplateUrl -Method Post -Body $AssignedIdentitiesPayload -ContentType $Type -Headers $Headers
     if ( $AssignedIdentitiesResponse.StatusCode -eq 200) {
         $AssignIdentitiesInfo = $AssignedIdentitiesResponse.Content | ConvertFrom-Json
         $AssignIdentitiesInfo = $AssignIdentitiesInfo | ConvertTo-Json -Depth 6
@@ -339,7 +319,7 @@ function Get-DeviceIdList($IpAddress, $Headers, $Type, $Url) {
     $DeviceIdList = @()
     $NextLinkUrl = $null
     $BaseUri = "https://$($IpAddress)"
-    $DevResp = Invoke-WebRequest -Uri $Url -Method Get -Headers $Headers -ContentType $Type
+    $DevResp = Invoke-WebRequest -SkipCertificateCheck -Uri $Url -Method Get -Headers $Headers -ContentType $Type
     if ($DevResp.StatusCode -eq 200) {
         $DevInfo = $DevResp.Content | ConvertFrom-Json
         if ($DevInfo.'@odata.count' -gt 0 ) {
@@ -348,7 +328,7 @@ function Get-DeviceIdList($IpAddress, $Headers, $Type, $Url) {
                 $NextLinkUrl = $BaseUri + $DevInfo.'@odata.nextLink'
             }
             while ($NextLinkUrl) {
-                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+                $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($NextLinkResponse.StatusCode -eq 200) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $NextLinkData.'value' | Sort-Object Id | ForEach-Object { $DeviceIdList += , $_.Id }
@@ -375,7 +355,7 @@ function New-Template($IpAddress, $Headers, $Type, $SourceId, $Component ) {
     $TemplatePayload = Get-TemplatePayload $SourceId $Component
     $TemplatePayload = $TemplatePayload | ConvertTo-Json -Depth 6
     $TemplateId = $null
-    $TemplateResponse = Invoke-WebRequest -Uri $TemplateUrl -Method Post -Body $TemplatePayload -ContentType $Type -Headers $Headers
+    $TemplateResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $TemplateUrl -Method Post -Body $TemplatePayload -ContentType $Type -Headers $Headers
     Write-Host "Creating Template..."
     if ($TemplateResponse.StatusCode -eq 201) {
         $TemplateId = $TemplateResponse.Content | ConvertFrom-Json
@@ -394,7 +374,7 @@ function New-Template($IpAddress, $Headers, $Type, $SourceId, $Component ) {
 function Get-GroupIdList ($IpAddress, $Headers, $Type) {
     $GroupIdList = @()
     $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups"
-    $GroupResp = Invoke-WebRequest -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
+    $GroupResp = Invoke-WebRequest -SkipCertificateCheck -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
     if ($GroupResp.StatusCode -eq 200) {
         $GroupInfo = $GroupResp.Content | ConvertFrom-Json
         if ($GroupInfo.'@odata.count' -gt 0 ) {
@@ -405,7 +385,6 @@ function Get-GroupIdList ($IpAddress, $Headers, $Type) {
 }
 
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
     $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups($($GroupId))/Devices"
@@ -415,7 +394,7 @@ Try {
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
     $IdList = @()
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests

--- a/PowerShell/Edit-DiscoveryJob.ps1
+++ b/PowerShell/Edit-DiscoveryJob.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -61,27 +63,6 @@ param(
     [parameter(ParameterSetName = 'Discover_Ip')]
     [String[]]$IpArray
 )
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
 
 function Get-DiscoverConfigPayload() {
     $DiscoveryConfigDetails = '{
@@ -154,7 +135,7 @@ function Get-JobStatus($IpAddress, $Headers, $Type, $JobName) {
     Write-Host "Polling job status"
     $SLEEP_INTERVAL = 3
     Start-Sleep -Seconds $SLEEP_INTERVAL
-    $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Method Get -Headers $Headers -ContentType $Type
+    $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Method Get -Headers $Headers -ContentType $Type
     if ($JobResp.StatusCode -eq 200) {
         $JobInfo = $JobResp.Content | ConvertFrom-Json
         $JobList = $JobInfo.value
@@ -164,7 +145,7 @@ function Get-JobStatus($IpAddress, $Headers, $Type, $JobName) {
                 $NextLinkUrl = $BaseUri + $JobInfo.'@odata.nextLink'
             }
             while ($NextLinkUrl) {
-                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+                $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($NextLinkResponse.StatusCode -eq 200) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $JobList += $NextLinkData.'value'
@@ -208,7 +189,7 @@ function Update-Config-Payload($IpAddress, $DeviceUserName, $DevicePassword, $Jo
     $DiscoveryConfigModels = @()
     $CredentialsList = @()
     $DiscoveryConfigUrl = "https://$($IpAddress)/api/DiscoveryConfigService/DiscoveryConfigGroups"
-    $DiscoveryResp = Invoke-WebRequest -Uri $DiscoveryConfigUrl -Method Get -Headers $Headers -ContentType $Type
+    $DiscoveryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DiscoveryConfigUrl -Method Get -Headers $Headers -ContentType $Type
     $Payload = Get-DiscoverConfigPayload
     $ConfigGrpId = $null
     $DiscoveryConfigTargets = @()
@@ -256,7 +237,7 @@ function Update-Config-Payload($IpAddress, $DeviceUserName, $DevicePassword, $Jo
             $ModifyConfigGrpURL = "https://$($IpAddress)/api/DiscoveryConfigService/DiscoveryConfigGroups($($ConfigGrpId))"
             Write-Host "URL = $($ModifyConfigGrpURL)"
             $Body = $Payload | ConvertTo-Json -Depth 6
-            $Response = Invoke-WebRequest -Uri $ModifyConfigGrpURL -Headers $Headers -ContentType $Type -Method PUT -Body $Body
+            $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $ModifyConfigGrpURL -Headers $Headers -ContentType $Type -Method PUT -Body $Body
             if ($Response.StatusCode -eq 200) {
                 Write-Host "Successfully modified the discovery config group"
                 Get-JobStatus $IpAddress $Headers $Type $JobNamePattern
@@ -276,7 +257,6 @@ function Update-Config-Payload($IpAddress, $DeviceUserName, $DevicePassword, $Jo
 
 
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $DiscoverUrl = "https://$($IPAddress)/api/DiscoveryConfigService/DiscoveryConfigGroups"
     $Type = "application/json"
@@ -285,7 +265,7 @@ Try {
     $UserDetails = @{ "UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{ }
     $ipAddressList = Test-IpAddress $IpArray
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Update-Config-Payload $IpAddress $DeviceUserName $DevicePassword $JobNamePattern $ipAddressList

--- a/PowerShell/Find-NonPmpCapableDevices.ps1
+++ b/PowerShell/Find-NonPmpCapableDevices.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Ashish Singh <ashish_singh11@Dell.com>
 Copyright (c) 2022 Dell EMC Corporation
@@ -49,30 +51,7 @@ param(
     [pscredential] $Credentials
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $BaseUri = "https://$($IpAddress)"
     $DeviceCountUrl = $BaseUri + "/api/DeviceService/Devices"
@@ -85,14 +64,14 @@ Try {
 
     Write-Host 'The Power Manager scripts were originally internal Dell scripts we then published externally. If you see this message and are using one of these scripts it would be very helpful if you open an issue on GitHub at https://github.com/dell/OpenManage-Enterprise/issues and tell us you are using the script. We have not dedicated any resources to optimizing them but are happy to do so if we know the community is using them. Likewise if you find a bug in one of these scripts feel free to open an issue and we will investigate.'
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         $DeviceData = @()
         $Total = @()
-        $DevCountResp = Invoke-WebRequest -Uri $DeviceCountUrl -Method Get -Headers $Headers -ContentType $Type
+        $DevCountResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DeviceCountUrl -Method Get -Headers $Headers -ContentType $Type
         if ($DevCountResp.StatusCode -eq 200) {
             $DeviceCountData = $DevCountResp.Content | ConvertFrom-Json
             $DeviceData += $DeviceCountData.'value'
@@ -100,7 +79,7 @@ Try {
             $toskip = 50
 
             $NextLinkUrl = $DeviceCountUrl + "?`$skip=$($toskip)&`$top=$($Total)"
-            $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+            $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
             if ($NextLinkResponse.StatusCode -eq 200) {
                 $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                 $DeviceData += $NextLinkData.'value'  

--- a/PowerShell/Find-NonPowerPolicyCapableDevices.ps1
+++ b/PowerShell/Find-NonPowerPolicyCapableDevices.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Ashish Singh <ashish_singh11@Dell.com>
 Copyright (c) 2018 Dell EMC Corporation
@@ -49,32 +51,9 @@ param(
     [pscredential] $Credentials
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 Try {
     Write-Host 'The Power Manager scripts were originally internal Dell scripts we then published externally. If you see this message and are using one of these scripts it would be very helpful if you open an issue on GitHub at https://github.com/dell/OpenManage-Enterprise/issues and tell us you are using the script. We have not dedicated any resources to optimizing them but are happy to do so if we know the community is using them. Likewise if you find a bug in one of these scripts feel free to open an issue and we will investigate.'
 
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $BaseUri = "https://$($IpAddress)"
     $DeviceCountUrl = $BaseUri + "/api/DeviceService/Devices"
@@ -85,14 +64,14 @@ Try {
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         $DeviceData = @()
         $Total = @()
-        $DevCountResp = Invoke-WebRequest -Uri $DeviceCountUrl -Method Get -Headers $Headers -ContentType $Type
+        $DevCountResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DeviceCountUrl -Method Get -Headers $Headers -ContentType $Type
         if ($DevCountResp.StatusCode -eq 200) {
             $DeviceCountData = $DevCountResp.Content | ConvertFrom-Json
             $DeviceData += $DeviceCountData.'value'
@@ -100,7 +79,7 @@ Try {
             $toskip = 50
 
             $NextLinkUrl = $DeviceCountUrl + "?`$skip=$($toskip)&`$top=$($Total)"
-            $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+            $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
             if ($NextLinkResponse.StatusCode -eq 200) {
                 $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                 $DeviceData += $NextLinkData.'value'  

--- a/PowerShell/Get-ChassisInventory.ps1
+++ b/PowerShell/Get-ChassisInventory.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -51,34 +53,12 @@ param(
 )
 
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-    using System.Net;
-    using System.Security.Cryptography.X509Certificates;
-    public class TrustAllCertsPolicy : ICertificatePolicy {
-        public bool CheckValidationResult(
-            ServicePoint srvPoint, X509Certificate certificate,
-            WebRequest request, int certificateProblem) {
-            return true;
-        }
-    }
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 function Get-ManagedDeviceCount($IpAddress, $Headers, $Type) {
     Try {
         $Count = 0
         $CountUrl = "https://$($IpAddress)/api/DeviceService/Devices" + "?`$count=true&`$top=0"
         Write-Host "Determining number of managed devices ..."
-        $CountResp = Invoke-WebRequest -Uri $CountUrl -Method Get -Headers $Headers -ContentType $Type
+        $CountResp = Invoke-WebRequest -SkipCertificateCheck -Uri $CountUrl -Method Get -Headers $Headers -ContentType $Type
         if ( $CountResp.StatusCode -eq 200) {
             $CountInfo = $CountResp.Content | ConvertFrom-Json
             $Count = $CountInfo.'@odata.count'
@@ -180,7 +160,7 @@ function Get-ServerMacAddress ($DeviceInfo, $IpAddress, $Headers, $Type) {
         $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
         $DeviceInventoryUrl = $DeviceUrl + "($($DeviceId))/InventoryDetails('serverNetworkInterfaces')"
         Try {
-            $DeviceInventoryResp = Invoke-WebRequest -Uri $DeviceInventoryUrl -Method Get -Headers $Headers -ContentType $Type
+            $DeviceInventoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DeviceInventoryUrl -Method Get -Headers $Headers -ContentType $Type
         }
         catch {
             $err = $_.Exception
@@ -245,7 +225,7 @@ function Get-DeviceInventory($IpAddress, $Headers, $Type) {
         if ($DeviceCount -gt 0) {
             $AllDeviceUrl = $DeviceUrl + "?`$skip=0&`$top=$($DeviceCount)"
             Write-Host "Enumerating all device info ..."
-            $AllDeviceResp = Invoke-WebRequest -Uri $AllDeviceUrl -Method Get -Headers $Headers -ContentType $Type
+            $AllDeviceResp = Invoke-WebRequest -SkipCertificateCheck -Uri $AllDeviceUrl -Method Get -Headers $Headers -ContentType $Type
             if ($AllDeviceResp.StatusCode -eq 200) {
                 $AllDeviceInfo = $AllDeviceResp.Content | ConvertFrom-Json
                 Write-Host "Iterating through devices and correlating data ..."
@@ -364,14 +344,13 @@ function Get-DeviceInventory($IpAddress, $Headers, $Type) {
 }
 
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
     $UserName = $Credentials.username
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Get-DeviceInventory $IpAddress $Headers $Type

--- a/PowerShell/Get-DeviceInventory.ps1
+++ b/PowerShell/Get-DeviceInventory.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -75,30 +77,7 @@ param(
   [String] $DeviceInfo
 )
 
-function Set-CertPolicy() {
-  ## Trust all certs - for sample usage only
-  Try {
-    add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  }
-  catch {
-    Write-Error "Unable to add type for cert policy"
-  }
-}
-
 Try {
-  Set-CertPolicy
   $FilterMap = @{'Name' = 'DeviceName'; 'Id' = 'Id'; 'SvcTag' = 'DeviceServiceTag' }
   $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
   $InventoryTypeMap = @{"cpus" = "serverProcessors"; "os" = "serverOperatingSystems"; "disks" = "serverArrayDisks"; "controllers" = "serverRaidControllers"; "memory" = "serverMemoryDevices" }
@@ -117,12 +96,12 @@ Try {
   else {
     $DevUrl = "$($BaseUrl) '$($DeviceInfo)'"
   }
-  $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+  $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
   if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
     ## Successfully created a session - extract the auth token from the response
     ## header and update our headers for subsequent requests
     $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-    $DevResp = Invoke-WebRequest -Uri $DevUrl -Headers $Headers -Method Get -ContentType $Type
+    $DevResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DevUrl -Headers $Headers -Method Get -ContentType $Type
     if ($DevResp.StatusCode -eq 200) {
       $DevInfo = $DevResp.Content | ConvertFrom-Json
       if ($DevInfo.'@odata.count' -gt 0) {
@@ -131,7 +110,7 @@ Try {
         if ($InventoryType) {
           $InventoryUrl = "https://$($IpAddress)/api/DeviceService/Devices($($DeviceId))/InventoryDetails('$($InventoryTypeMap[$InventoryType])')"
         }
-        $InventoryResp = Invoke-WebRequest -Uri $InventoryUrl -Headers $Headers -Method Get -ContentType $Type
+        $InventoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $InventoryUrl -Headers $Headers -Method Get -ContentType $Type
         if ($InventoryResp.StatusCode -eq 200) {
           $InventoryInfo = $InventoryResp.Content | ConvertFrom-Json
           $InventoryDetails = $InventoryInfo | ConvertTo-Json -Depth 6

--- a/PowerShell/Get-GroupDetails.ps1
+++ b/PowerShell/Get-GroupDetails.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -59,34 +61,11 @@ param(
     [String] $GroupInfo
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 
 
 
 
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups"
     $Type = "application/json"
@@ -94,12 +73,12 @@ Try {
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $GrpResp = Invoke-WebRequest -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
+        $GrpResp = Invoke-WebRequest -SkipCertificateCheck -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
         if ($GrpResp.StatusCode -eq 200) {
             ## Iterate over groups and see if a match is found for given criteria
             $GrpInfo = $GrpResp.Content | ConvertFrom-Json
@@ -111,7 +90,7 @@ Try {
                 if ($groupCount -gt $currGroupCount) {
                     $delta = $groupCount - $currGroupCount
                     $RemainingGroupUrl = $GroupUrl + "?`$skip=$($currGroupCount)&`$top=$($delta)"
-                    $remainingGroupResp = Invoke-WebRequest -Uri $RemainingGroupUrl -Method Get -Headers $Headers -ContentType $Type
+                    $remainingGroupResp = Invoke-WebRequest -SkipCertificateCheck -Uri $RemainingGroupUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($remainingGroupResp.StatusCode -eq 200) {
                         $remGroupInfo = $remainingGroupResp.Content | ConvertFrom-Json
                         $groupList += $remGroupInfo.value
@@ -125,7 +104,7 @@ Try {
                         Write-Output "*** Group Details ***"
                         $Group | Format-List
                         $DevUrl = $GroupUrl + "(" + [String]($Group.Id) + ")/Devices"
-                        $DevResp = Invoke-WebRequest -Uri $DevUrl -Method Get -Headers $Headers -ContentType $Type
+                        $DevResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DevUrl -Method Get -Headers $Headers -ContentType $Type
                         if ($DevResp.StatusCode -eq 200) {
                             $DevInfo = $DevResp.Content | ConvertFrom-Json
                             $DevList = $DevInfo.value
@@ -135,7 +114,7 @@ Try {
                                 if ($deviceCount -gt $currDeviceCount) {
                                     $delta = $deviceCount - $currDeviceCount 
                                     $RemainingDeviceurl = $DevUrl + "?`$skip=$($currDeviceCount)&`$top=$($delta)"
-                                    $RemainingDeviceResp = Invoke-WebRequest -Uri $RemainingDeviceurl -Method Get -Headers $Headers -ContentType $Type
+                                    $RemainingDeviceResp = Invoke-WebRequest -SkipCertificateCheck -Uri $RemainingDeviceurl -Method Get -Headers $Headers -ContentType $Type
                                     if ($RemainingDeviceResp.StatusCode -eq 200) {
                                         $RemainingDeviceInfo = $RemainingDeviceResp.Content | ConvertFrom-Json
                                         $DevList += $RemainingDeviceInfo.value

--- a/PowerShell/Get-GroupDetailsByFilter.ps1
+++ b/PowerShell/Get-GroupDetailsByFilter.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -66,30 +68,7 @@ param(
     [String] $GroupInfo    
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups?`$filter=$($FilterBy) eq '$($GroupInfo)'"
     $Type = "application/json"
@@ -98,12 +77,12 @@ Try {
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
     $Headers = @{}
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         ## Successfully created a session - extract the auth token from the response
         ## header and update our headers for subsequent requests
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
-        $GrpResp = Invoke-WebRequest -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
+        $GrpResp = Invoke-WebRequest -SkipCertificateCheck -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
         if ($GrpResp.StatusCode -eq 200) {
             $GrpInfo = $GrpResp.Content | ConvertFrom-Json
             if ($GrpInfo.'@odata.count' -gt 0) {
@@ -113,7 +92,7 @@ Try {
                 $GrpInfo.value | Format-List
 
                 $DevUrl = "https://$($IpAddress)/api/GroupService/Groups($($GroupId))/Devices"
-                $DevResp = Invoke-WebRequest -Uri $DevUrl -Method Get -Headers $Headers -ContentType $Type
+                $DevResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DevUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($DevResp.StatusCode -eq 200) {
                     $DevInfo = $DevResp.Content | ConvertFrom-Json
                     if ($DevInfo.'@odata.count' -gt 0) {

--- a/PowerShell/Get-IdentityPoolUsage.ps1
+++ b/PowerShell/Get-IdentityPoolUsage.ps1
@@ -1,4 +1,6 @@
-﻿<#
+﻿#Requires -Version 7
+
+<#
 _author_ = Trevor Squillario <Trevor.Squillario@Dell.com>
 
 Copyright (c) 2022 Dell EMC Corporation
@@ -66,28 +68,6 @@ param(
     [String] $OutFile
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 $SessionAuthToken = @{}
 
 function Get-Session($IpAddress, $Credentials) {
@@ -97,7 +77,7 @@ function Get-Session($IpAddress, $Credentials) {
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         $SessionAuthToken = @{
@@ -111,11 +91,10 @@ function Get-Session($IpAddress, $Credentials) {
 function Remove-Session($IpAddress, $Headers, $Id) {
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
     $Type = "application/json"
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
 }
 
 Try {
-    Set-CertPolicy
     $BaseUri = "https://$($IpAddress)"
     $NextLinkUrl = $null
     $Type = "application/json"
@@ -129,7 +108,7 @@ Try {
         
         # Display Identity Pools
         $IdentityPoolUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools"
-        $IdentityPoolResp = Invoke-WebRequest -Uri $IdentityPoolUrl -Method Get -Headers $Headers -ContentType $Type
+        $IdentityPoolResp = Invoke-WebRequest -SkipCertificateCheck -Uri $IdentityPoolUrl -Method Get -Headers $Headers -ContentType $Type
         if ($IdentityPoolResp.StatusCode -eq 200) {
             $IdentityPoolRespData = $IdentityPoolResp.Content | ConvertFrom-Json
             $IdentityPoolRespData = $IdentityPoolRespData.'value'
@@ -142,7 +121,7 @@ Try {
 
         # Get Identity Pool Usage Sets
         $IdentityPoolUsageSetUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets"
-        $IdentityPoolUsageSetResp = Invoke-WebRequest -Uri $IdentityPoolUsageSetUrl -Method Get -Headers $Headers -ContentType $Type
+        $IdentityPoolUsageSetResp = Invoke-WebRequest -SkipCertificateCheck -Uri $IdentityPoolUsageSetUrl -Method Get -Headers $Headers -ContentType $Type
         if ($IdentityPoolUsageSetResp.StatusCode -eq 200) {
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetResp.Content | ConvertFrom-Json
             $IdentityPoolUsageSetRespData = $IdentityPoolUsageSetRespData.'value'
@@ -154,7 +133,7 @@ Try {
                 $IdentitySetName = $IdentitySet.Name
 
                 $IdentityPoolUsageDetailUrl = $BaseUri + "/api/IdentityPoolService/IdentityPools($($Id))/UsageIdentitySets($($IdentitySetId))/Details"
-                $IdentityPoolUsageDetailResp = Invoke-WebRequest -Uri $IdentityPoolUsageDetailUrl -Method Get -Headers $Headers -ContentType $Type
+                $IdentityPoolUsageDetailResp = Invoke-WebRequest -SkipCertificateCheck -Uri $IdentityPoolUsageDetailUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($IdentityPoolUsageDetailResp.StatusCode -eq 200) {
                     $IdentityPoolUsageDetailData = $IdentityPoolUsageDetailResp.Content | ConvertFrom-Json
                     # Loop through Details appending to object array
@@ -176,7 +155,7 @@ Try {
                     }
                     # Loop through pages until end
                     while ($NextLinkUrl) {
-                        $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+                        $IdentityPoolUsageDetailNextLinkResp = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                         if ($IdentityPoolUsageDetailNextLinkResp.StatusCode -eq 200) {
                             $IdentityPoolUsageDetailNextLinkData = $IdentityPoolUsageDetailNextLinkResp.Content | ConvertFrom-Json
                             # Loop through Details appending to object array

--- a/PowerShell/Invoke-RefreshPowerManagerInventory.ps1
+++ b/PowerShell/Invoke-RefreshPowerManagerInventory.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Ashish Singh <ashish_singh11@Dell.com>
 
@@ -42,32 +44,11 @@ param(
 
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
 function Get-JobId($Headers) {
     $Jobname = 'Default Inventory Task'
     $JobId = -1
     $JobUrl = "https://$($IpAddress)/api/JobService/Jobs"
-    $JobResponse = Invoke-WebRequest -Uri $JobUrl -Headers $Headers -Method Get
+    $JobResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $JobUrl -Headers $Headers -Method Get
     if ($JobResponse.StatusCode -eq 200) {
         Write-Host "Job fetched"
         $JobInfo = $JobResponse.Content | ConvertFrom-Json
@@ -79,7 +60,7 @@ function Get-JobId($Headers) {
                 $NextLinkUrl = $BaseUri + $JobInfo.'@odata.nextLink'
             }
             while ($NextLinkUrl) {
-                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+                $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($NextLinkResponse.StatusCode -eq 200) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $JobList += $NextLinkData.'value'
@@ -121,13 +102,13 @@ function Get-JobStatus($JobId) {
     $UserName = $Credentials.username
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{ "UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         do {
             $Ctr++
         
-            $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+            $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
             $jobresp.Content
             if ($JobResp.StatusCode -eq 200) {
                 $JobData = $JobResp.Content | ConvertFrom-Json
@@ -144,7 +125,6 @@ function Get-JobStatus($JobId) {
 Try {
     Write-Host 'The Power Manager scripts were originally internal Dell scripts we then published externally. If you see this message and are using one of these scripts it would be very helpful if you open an issue on GitHub at https://github.com/dell/OpenManage-Enterprise/issues and tell us you are using the script. We have not dedicated any resources to optimizing them but are happy to do so if we know the community is using them. Likewise if you find a bug in one of these scripts feel free to open an issue and we will investigate.'
 
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $RunJobUrl = "https://$($IpAddress)/api/JobService/Actions/JobService.RunJobs"
     $Type = "application/json"
@@ -152,14 +132,14 @@ Try {
     $UserName = $Credentials.username
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{ "UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         $InventoryJobId = Get-JobId($Headers)
         $jpl = '[' + $InventoryJobId + ']'
         $JobCreationpayload = @{ "JobIds" = $($jpl) } | ConvertTo-Json
         $JobCreationpayload = $JobCreationpayload.Replace("`"[", "[").Replace("]`"", "]")
-        $RunInventoryResponse = Invoke-WebRequest -Uri $RunJobUrl -Method Post  -Body $JobCreationpayload -Headers $Headers -ContentType $Type
+        $RunInventoryResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $RunJobUrl -Method Post  -Body $JobCreationpayload -Headers $Headers -ContentType $Type
         if ( $RunInventoryResponse.StatusCode -eq 204) {
             Write-Host "Performing Inventory ..."
             <#Start-Sleep Seconds 10#>

--- a/PowerShell/Invoke-RetireLead.ps1
+++ b/PowerShell/Invoke-RetireLead.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Vittalareddy Nanjareddy <vittalareddy_nanjare@Dell.com>
 
@@ -45,28 +47,6 @@ param(
     [pscredential] $Credentials
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 
 function Retire-Lead($IpAddress, $Headers) {
     $BackupLead = $null
@@ -106,7 +86,7 @@ function Retire-Lead($IpAddress, $Headers) {
     }' | ConvertFrom-Json
 
     $Body = $Payload | ConvertTo-Json -Depth 6
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
     if ($Response.StatusCode -eq 200) {
         $RetireLeadResp = $Response | ConvertFrom-Json
         $JobId = $RetireLeadResp.'JobId'
@@ -135,7 +115,7 @@ function Assign-BackupLead($IpAddress, $Headers) {
         $TargetTempHash."Id" = $MemberId
         $TargetArray += $TargetTempHash
         $Body = ConvertTo-Json $TargetArray
-        $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $BackupLeadData = $Response | ConvertFrom-Json
             $JobId = $BackupLeadData.'JobId'
@@ -155,7 +135,7 @@ function Get-Domains($IpAddress, $Headers) {
     $Lead = $null
     $BackupLead = $null
     $URL = "https://$($IpAddress)/api/ManagementDomainService/Domains"
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -224,7 +204,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -237,12 +217,12 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -264,7 +244,6 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
 
 ## Script that does the work
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
     $UserName = $Credentials.username
@@ -273,13 +252,13 @@ Try {
     $Headers = @{}
 
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Write-Host "Successfully created session with $($IpAddress)"
         ## Sending in non-existent targets throws an exception with a "bad request"
         ## error. Doing some pre-req error checking as a result to validate input
-        ## This is a Powershell quirk on Invoke-WebRequest failing with an error
+        ## This is a Powershell quirk on Invoke-WebRequest -SkipCertificateCheck failing with an error
         # Create mcm group
         $JobId = 0
         $JobId = Retire-Lead $IpAddress $Headers

--- a/PowerShell/New-McmGroup.ps1
+++ b/PowerShell/New-McmGroup.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Vittalareddy Nanjareddy <vittalareddy_nanjare@Dell.com>
 
@@ -51,35 +53,13 @@ param(
     [String] $GroupName
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 
 function Get-DiscoveredDomains($IpAddress, $Headers, $Role) {
     $DiscoveredDomains = @()
     $FilteredDiscoveredDomains = @()
     $TargetArray = @()
     $URL = "https://$($IpAddress)/api/ManagementDomainService/DiscoveredDomains"
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -150,7 +130,7 @@ function Create-McmGroup($IpAddress, $Headers, $GroupName) {
     $JobId = 0
     $Payload."GroupName" = $GroupName
     $Body = $payload | ConvertTo-Json -Depth 6
-    $Response = Invoke-WebRequest -Uri $CreateGroupURL -Headers $Headers -ContentType $Type -Method PUT -Body $Body 
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $CreateGroupURL -Headers $Headers -ContentType $Type -Method PUT -Body $Body 
     if ($Response.StatusCode -eq 200) {
         $GroupData = $Response | ConvertFrom-Json
         $JobId = $GroupData.'JobId'
@@ -177,7 +157,7 @@ function Add-AllMembersViaLead($IpAddress, $Headers) {
         $Body = $Payload 
         Write-Host "Adding members to the group..."
         Write-Host "Invoking URL $($ManagementDomainURL)"
-        $Response = Invoke-WebRequest -Uri $ManagementDomainURL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $ManagementDomainURL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $ManagementData = $Response | ConvertFrom-Json
             $JobId = $ManagementData.'JobId'
@@ -209,7 +189,7 @@ function Assign-BackupLead($IpAddress, $Headers) {
         Write-Host "Assigning backup lead..."
         Write-Host "Invoking URL $($URL)"
         Write-Host "Payload $($Body)"
-        $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
+        $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method POST -Body $Body 
         if ($Response.StatusCode -eq 200) {
             $BackupLeadData = $Response | ConvertFrom-Json
             $JobId = $BackupLeadData.'JobId'
@@ -227,7 +207,7 @@ function Get-Domains($IpAddress, $Headers) {
     $Members = @()
     $ListOfMembers = @()
     $URL = "https://$($IpAddress)/api/ManagementDomainService/Domains"
-    $Response = Invoke-WebRequest -Uri $URL -Headers $Headers -ContentType $Type -Method GET
+    $Response = Invoke-WebRequest -SkipCertificateCheck -Uri $URL -Headers $Headers -ContentType $Type -Method GET
     if ($Response.StatusCode -eq 200) {
         $DomainResp = $Response.Content | ConvertFrom-Json
         if ($DomainResp."value".Length -gt 0) {
@@ -274,7 +254,7 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
     do {
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = [string]$JobData.LastRunStatus.Id
@@ -287,12 +267,12 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -316,7 +296,6 @@ function Wait-OnJobStatus($IpAddress, $Headers, $Type, $JobId) {
 
 ## Script that does the work
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
     $UserName = $Credentials.username
@@ -325,13 +304,13 @@ Try {
     $Headers = @{}
 
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Write-Host "Successfully created session with $($IpAddress)"
         ## Sending in non-existent targets throws an exception with a "bad request"
         ## error. Doing some pre-req error checking as a result to validate input
-        ## This is a Powershell quirk on Invoke-WebRequest failing with an error
+        ## This is a Powershell quirk on Invoke-WebRequest -SkipCertificateCheck failing with an error
         # Create mcm group
         $JobId = 0
         Write-Host "Creating mcm group"

--- a/PowerShell/New-Network.ps1
+++ b/PowerShell/New-Network.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Trevor Squillario <Trevor.Squillario@Dell.com>
 
@@ -89,29 +91,6 @@ param(
     [string] $InFile
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-
-}
-
 $SessionAuthToken = @{}
 
 function Get-Session($IpAddress, $Credentials) {
@@ -121,7 +100,7 @@ function Get-Session($IpAddress, $Credentials) {
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
         $SessionAuthToken = @{
@@ -135,14 +114,14 @@ function Get-Session($IpAddress, $Credentials) {
 function Remove-Session($IpAddress, $Headers, $Id) {
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
     $Type = "application/json"
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
 }
 
 function Get-Networks($BaseUri, $Headers) {
     # Display Networks
     $Type = "application/json"
     $NetworkUrl = $BaseUri + "/api/NetworkConfigurationService/Networks"
-    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
+    $NetworkResp = Invoke-WebRequest -SkipCertificateCheck -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
     if ($NetworkResp.StatusCode -eq 200) {
         $NetworkRespData = $NetworkResp.Content | ConvertFrom-Json
         $NetworkRespData = $NetworkRespData.'value'
@@ -155,7 +134,7 @@ function Get-NetworkTypes($BaseUri, $Headers) {
     # Display Network Types
     $Type = "application/json"
     $NetworkTypeUrl = $BaseUri + "/api/NetworkConfigurationService/NetworkTypes"
-    $NetworkTypeResp = Invoke-WebRequest -Uri $NetworkTypeUrl -Method Get -Headers $Headers -ContentType $Type
+    $NetworkTypeResp = Invoke-WebRequest -SkipCertificateCheck -Uri $NetworkTypeUrl -Method Get -Headers $Headers -ContentType $Type
     if ($NetworkTypeResp.StatusCode -eq 200) {
         $NetworkTypeRespData = $NetworkTypeResp.Content | ConvertFrom-Json
         $NetworkTypeRespData = $NetworkTypeRespData.'value'
@@ -177,7 +156,6 @@ function Export-ExampleCSV() {
 }
 
 Try {
-    Set-CertPolicy
     $BaseUri = "https://$($IpAddress)"
     $Type = "application/json"
     $Headers = @{}
@@ -219,7 +197,7 @@ Try {
                 # Create Network
                 Try {
                     $CreateNetworkUrl = $BaseUri + "/api/NetworkConfigurationService/Networks"
-                    $CreateResp = Invoke-WebRequest -Uri $CreateNetworkUrl -Me Post -H $Headers -Con $Type -Body $PayloadJson
+                    $CreateResp = Invoke-WebRequest -SkipCertificateCheck -Uri $CreateNetworkUrl -Me Post -H $Headers -Con $Type -Body $PayloadJson
                     if ($CreateResp.StatusCode -eq 201) {
                         Write-Host "New Network created $($_)"
                     }

--- a/PowerShell/Set-ScaleVlanProfile.ps1
+++ b/PowerShell/Set-ScaleVlanProfile.ps1
@@ -1,3 +1,5 @@
+#Requires -Version 7
+
 <#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
@@ -157,30 +159,6 @@ function fShowMenu([System.String]$sMenuTitle, [System.Collections.IDictionary]$
     }
 }
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    ## customers are expected to use strict cert validation
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-
-}
-
 function Get-Session($IpAddress, $Credentials) {
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
@@ -188,7 +166,7 @@ function Get-Session($IpAddress, $Credentials) {
     $Password = $Credentials.GetNetworkCredential().password
     $UserDetails = @{"UserName" = $UserName; "Password" = $Password; "SessionType" = "API" } | ConvertTo-Json
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 200 -or $SessResponse.StatusCode -eq 201) {
         Write-Host "Successful authentication with $($IpAddress)"
         $SessResponseData = $SessResponse.Content | ConvertFrom-Json
@@ -203,7 +181,7 @@ function Get-Session($IpAddress, $Credentials) {
 function Remove-Session($IpAddress, $Headers, $Id) {
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions('$($Id)')"
     $Type = "application/json"
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Delete -Headers $Headers -ContentType $Type
     Write-Host "Deleted authentication token ..."
 }
 
@@ -212,7 +190,7 @@ function Get-Networks($BaseUri, $Headers) {
     $Type = "application/json"
     $NetworkUrl = $BaseUri + "/api/NetworkService/Fabrics"
     Write-Host "Enumerating fabrics ..."
-    $NetworkResp = Invoke-WebRequest -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
+    $NetworkResp = Invoke-WebRequest -SkipCertificateCheck -Uri $NetworkUrl -Method Get -Headers $Headers -ContentType $Type
     $FabricData = @()
     $FabricLookup = @{}
     $NextLinkUrl = $null
@@ -226,7 +204,7 @@ function Get-Networks($BaseUri, $Headers) {
                 $NextLinkUrl = $BaseUri + $NetworkRespData.'@odata.nextLink'
             }
             while ($NextLinkUrl) {
-                $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+                $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($NextLinkResponse.StatusCode -eq 200) {
                     $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                     $FabricData += $NextLinkData.'value'
@@ -261,7 +239,7 @@ function Set-ScaleVlanProfileProperty($BaseUri, $Headers, $selection, $FabricDat
     $Type = "application/json"
     Write-Host "Enumerating Fabric Design ...."
     $DesignURL = $BaseUri + "/api/NetworkService/Fabrics" + "('" + "$($selection)" + "')/FabricDesign"
-    $DesignResp = Invoke-WebRequest -Uri $DesignURL -Method Get -H $Headers -Con $Type
+    $DesignResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DesignURL -Method Get -H $Headers -Con $Type
     if ($DesignResp.StatusCode -eq 200) {
         $DesignRespData = $DesignResp.Content | ConvertFrom-Json
         $foo = @{"Name" = $DesignRespData.Name }
@@ -269,7 +247,7 @@ function Set-ScaleVlanProfileProperty($BaseUri, $Headers, $selection, $FabricDat
         $PayloadInfo = $FabricData | Select-Object Name, Id, Description, ScaleVlanProfile, FabricDesignMapping, OverrideLLDPConfiguration, FabricDesign | ConvertTo-Json -Depth 4 | ForEach-Object { [System.Text.RegularExpressions.Regex]::Unescape($_) }
         Write-Host "Modifying ScaleVLANProfile property ....."
         $ActionURL = $BaseUri + "/api/NetworkService/Fabrics" + "('" + "$($selection)" + "')"    
-        $ReplaceResp = Invoke-WebRequest -Uri $ActionURL -Me Put -H $Headers -Con $Type -Body $PayloadInfo
+        $ReplaceResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ActionURL -Me Put -H $Headers -Con $Type -Body $PayloadInfo
         if ($ReplaceResp.StatusCode -eq 201 -or $ReplaceResp.StatusCode -eq 200) {
             Write-Host "Successfully modified ScaleVlanProfile property ...."
         }
@@ -284,7 +262,6 @@ function Set-ScaleVlanProfileProperty($BaseUri, $Headers, $selection, $FabricDat
 }
 
 Try {
-    Set-CertPolicy
     $IpAddress = $OmemIPAddr
     $BaseUri = "https://$($IpAddress)"
     $Type = "application/json"

--- a/PowerShell/Update-InstalledFirmwareWithDup.ps1
+++ b/PowerShell/Update-InstalledFirmwareWithDup.ps1
@@ -1,4 +1,6 @@
-﻿<#
+﻿#Requires -Version 7
+
+<#
 _author_ = Raajeev Kalyanaraman <raajeev.kalyanaraman@Dell.com>
 
 Copyright (c) 2022 Dell EMC Corporation
@@ -71,32 +73,10 @@ param(
     [System.UInt32]$DeviceId
 )
 
-function Set-CertPolicy() {
-    ## Trust all certs - for sample usage only
-    Try {
-        add-type @"
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-public class TrustAllCertsPolicy : ICertificatePolicy {
-    public bool CheckValidationResult(
-        ServicePoint srvPoint, X509Certificate certificate,
-        WebRequest request, int certificateProblem) {
-        return true;
-    }
-}
-"@
-        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    }
-    catch {
-        Write-Error "Unable to add type for cert policy"
-    }
-}
-
 function Get-GroupList($IpAddress, $Headers, $Type) {
     $GroupList = @()
     $GroupUrl = "https://$($IpAddress)/api/GroupService/Groups"
-    $GrpResp = Invoke-WebRequest -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
+    $GrpResp = Invoke-WebRequest -SkipCertificateCheck -Uri $GroupUrl -Method Get -Headers $Headers -ContentType $Type
     if ($GrpResp.StatusCode -eq 200) {
         $GroupInfo = $GrpResp.Content | ConvertFrom-Json
         $GroupInfo.'value' |  Sort-Object Id | ForEach-Object { $GroupList += , $_.Id }
@@ -109,7 +89,7 @@ function Get-DeviceList($IpAddress, $Headers, $Type) {
     $BaseUri = "https://$($IpAddress)"
     $DeviceList = @()
     $DeviceUrl = "https://$($IpAddress)/api/DeviceService/Devices"
-    $DevResp = Invoke-WebRequest -Uri $DeviceUrl -Method Get -Headers $Headers -ContentType $Type
+    $DevResp = Invoke-WebRequest -SkipCertificateCheck -Uri $DeviceUrl -Method Get -Headers $Headers -ContentType $Type
     if ($DevResp.StatusCode -eq 200) {
         $DevInfo = $DevResp.Content | ConvertFrom-Json
         $DevInfo.'value' |  Sort-Object Id | ForEach-Object { $DeviceList += , $_.Id }
@@ -118,7 +98,7 @@ function Get-DeviceList($IpAddress, $Headers, $Type) {
             $NextLinkUrl = $BaseUri + $DevInfo.'@odata.nextLink'
         }
         while ($NextLinkUrl) {
-            $NextLinkResponse = Invoke-WebRequest -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
+            $NextLinkResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $NextLinkUrl -Method Get -Headers $Headers -ContentType $Type
             if ($NextLinkResponse.StatusCode -eq 200) {
                 $NextLinkData = $NextLinkResponse.Content | ConvertFrom-Json
                 $NextLinkData.'value' | Sort-Object Id | ForEach-Object { $DeviceList += , $_.Id }
@@ -141,7 +121,7 @@ function Push-DupToOME($IpAddress, $Headers, $DupFile) {
     $FileToken = $null
     $UploadActionUri = "https://$($IpAddress)/api/UpdateService/Actions/UpdateService.UploadFile"
     Write-Host "Uploading $($DupFile) to $($IpAddress). This action may take some time to complete."
-    $UploadResponse = Invoke-WebRequest -Uri $UploadActionUri -Method Post -InFile $DupFile -ContentType "application/octet-stream" -Headers $Headers
+    $UploadResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $UploadActionUri -Method Post -InFile $DupFile -ContentType "application/octet-stream" -Headers $Headers
     if ($UploadResponse.StatusCode -eq 200) {
         ## Successfully uploaded the DUP file . Get the file token
         ## returned by OME on upload of the DUP file
@@ -225,7 +205,7 @@ function Get-ApplicableComponents($IpAddress, $Headers, $Type, $DupReportPayload
 
     $DupReportUrl = "https://$($IpAddress)/api/UpdateService/Actions/UpdateService.GetSingleDupReport"
     try {
-        $DupResponse = Invoke-WebRequest -Uri $DupReportUrl -Headers $Headers -ContentType $Type -Body $DupReportPayload -Method Post -ErrorAction SilentlyContinue       
+        $DupResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $DupReportUrl -Headers $Headers -ContentType $Type -Body $DupReportPayload -Method Post -ErrorAction SilentlyContinue       
         if ($DupResponse.StatusCode -eq 200) {
             $DupResponseInfo = $DupResponse.Content | ConvertFrom-Json
             if ($DupResponse.Length -gt 0) {
@@ -310,7 +290,7 @@ function Wait-OnUpdateJobs($IpAddress, $Headers, $Type, $JobId) {
     do {        
         $Ctr++
         Start-Sleep -Seconds $SLEEP_INTERVAL
-        $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
+        $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Headers $Headers -ContentType $Type -Method Get
         if ($JobResp.StatusCode -eq 200) {
             $JobData = $JobResp.Content | ConvertFrom-Json
             $JobStatus = $JobData.LastRunStatus.Id
@@ -323,12 +303,12 @@ function Wait-OnUpdateJobs($IpAddress, $Headers, $Type, $JobId) {
             elseif ($FailedJobStatuses -contains $JobStatus) {
                 Write-Warning "Update job failed .... "
                 $JobExecUrl = "$($JobSvcUrl)/ExecutionHistories"
-                $ExecResp = Invoke-WebRequest -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
+                $ExecResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobExecUrl -Method Get -Headers $Headers -ContentType $Type
                 if ($ExecResp.StatusCode -eq 200) {
                     $ExecRespInfo = $ExecResp.Content | ConvertFrom-Json
                     $HistoryId = $ExecRespInfo.value[0].Id
                     $ExecHistoryUrl = "$($JobExecUrl)($($HistoryId))/ExecutionHistoryDetails"
-                    $HistoryResp = Invoke-WebRequest -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
+                    $HistoryResp = Invoke-WebRequest -SkipCertificateCheck -Uri $ExecHistoryUrl -Method Get -Headers $Headers -ContentType $Type
                     if ($HistoryResp.StatusCode -eq 200) {
                         Write-Host ($HistoryResp.Content | ConvertFrom-Json | ConvertTo-Json -Depth 4)
                     }
@@ -350,7 +330,6 @@ function Wait-OnUpdateJobs($IpAddress, $Headers, $Type, $JobId) {
 
 ## Script that does the work
 Try {
-    Set-CertPolicy
     $SessionUrl = "https://$($IpAddress)/api/SessionService/Sessions"
     $Type = "application/json"
     $UserName = $Credentials.username
@@ -359,14 +338,14 @@ Try {
     $Headers = @{}
 
 
-    $SessResponse = Invoke-WebRequest -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
+    $SessResponse = Invoke-WebRequest -SkipCertificateCheck -Uri $SessionUrl -Method Post -Body $UserDetails -ContentType $Type
     if ($SessResponse.StatusCode -eq 201) {
         $Headers."X-Auth-Token" = $SessResponse.Headers["X-Auth-Token"]
         Write-Host "Successfully created session with $($IpAddress)`nParsing $($DupFile)"
         
         ## Sending in non-existent targets throws an exception with a "bad request"
         ## error. Doing some pre-req error checking as a result to validate input
-        ## This is a Powershell quirk on Invoke-WebRequest failing with an error
+        ## This is a Powershell quirk on Invoke-WebRequest -SkipCertificateCheck failing with an error
         if ($GroupId) {
             $GroupList = Get-GroupList $IpAddress $Headers $Type
             if ($GroupList -contains $GroupId) {}
@@ -398,7 +377,7 @@ Try {
                     Write-Host $DupUpdatePayload."Targets".Length
                     $JobBody = $DupUpdatePayload | ConvertTo-Json -Depth 6
                     $JobSvcUrl = "https://$($IpAddress)/api/JobService/Jobs"
-                    $JobResp = Invoke-WebRequest -Uri $JobSvcUrl -Method Post -Body $JobBody -Headers $Headers -ContentType $Type
+                    $JobResp = Invoke-WebRequest -SkipCertificateCheck -Uri $JobSvcUrl -Method Post -Body $JobBody -Headers $Headers -ContentType $Type
                     if ($JobResp.StatusCode -eq 201) {
                         $JobInfo = $JobResp.Content | ConvertFrom-Json
                         $JobId = $JobInfo.Id


### PR DESCRIPTION
## Summary

Every script still on the checklist in #60 uses a `Set-CertPolicy` function that `add-type`s a class implementing `ICertificatePolicy` to bypass certificate validation:

```powershell
add-type @"
using System.Net;
using System.Security.Cryptography.X509Certificates;
public class TrustAllCertsPolicy : ICertificatePolicy {
    ...
}
"@
```

`ICertificatePolicy` was removed in .NET Core, so under PowerShell 7 this `add-type` call throws `CS0246` ("The type or namespace name 'ICertificatePolicy' could not be found"), and every subsequent `Invoke-WebRequest`/`Invoke-RestMethod` call then fails with an SSL exception, since the cert bypass was never actually installed — matching the repro in #60.

This repo already has the fix for other scripts (e.g. `Get-GroupList.ps1`, `Get-ReportList.ps1`, `Set-PowerState.ps1`): drop `Set-CertPolicy` entirely and use PS7's built-in `-SkipCertificateCheck` parameter instead. This PR applies that same, already-established fix to every remaining script on the issue's checklist:

- Add-MembersToMcmGroup.ps1
- Deploy-Template.ps1
- Edit-DiscoveryJob.ps1
- Find-NonPmpCapableDevices.ps1
- Find-NonPowerPolicyCapableDevices.ps1
- Get-ChassisInventory.ps1
- Get-DeviceInventory.ps1
- Get-GroupDetails.ps1
- Get-GroupDetailsByFilter.ps1
- Get-IdentityPoolUsage.ps1
- Invoke-RefreshPowerManagerInventory.ps1
- Invoke-RetireLead.ps1
- New-McmGroup.ps1
- New-Network.ps1
- Set-ScaleVlanProfile.ps1
- Update-InstalledFirmwareWithDup.ps1

Each script: removed the `Set-CertPolicy` function and its call site, added `-SkipCertificateCheck` to every `Invoke-WebRequest` call, and added `#Requires -Version 7` at the top (matching the already-fixed scripts — `-SkipCertificateCheck` itself is PS7+ only, so this fails fast with a clear message on PS5 instead of the confusing error from #60).

Fixes #60

## Test plan
- [x] `[System.Management.Automation.Language.Parser]::ParseFile(...)` on all 16 modified scripts — 0 syntax errors
- [x] Confirmed no remaining `Set-CertPolicy`/`TrustAllCertsPolicy` references anywhere in `PowerShell/`
- [x] Confirmed every `Invoke-WebRequest` call site across the 16 files now carries `-SkipCertificateCheck`
- [x] Preserved each file's original encoding (3 of the 16 had a UTF-8 BOM) and CRLF line endings, so the diff is minimal and doesn't touch unrelated lines
- Not tested against a live OME appliance (none available in this environment) — the change is scoped narrowly to the cert-bypass mechanism the issue itself identifies as the fix, without touching request bodies, auth flow, or any other logic